### PR TITLE
limit API client version for current reporters

### DIFF
--- a/qase-pytest/setup.cfg
+++ b/qase-pytest/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    qaseio>=2.2.4
+    qaseio>=2.2.4,<3.0
     pytest>=5.2.0
     filelock>=3.0
 python_requires = >=3.7

--- a/qase-robotframework/setup.cfg
+++ b/qase-robotframework/setup.cfg
@@ -27,7 +27,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    qaseio>=2.0.0
+    qaseio>=2.0.0,<3.0
 python_requires = >=3.7
 
 [options.packages.find]

--- a/qase-xctest/setup.cfg
+++ b/qase-xctest/setup.cfg
@@ -22,7 +22,7 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
-    qaseio>=1.1.1
+    qaseio>=1.1.1,<3.0
     attrs>=19.3.0
 python_requires = >=3.6
 


### PR DESCRIPTION
I want to replace qaseio api client with generated version, which is not compatible with current versions of reporters, so I have limited api client version in requirements