### PR TITLE
Added option to disable warnings and upload attachments in case of te…

### DIFF
--- a/qase-robotframework/README.md
+++ b/qase-robotframework/README.md
@@ -75,6 +75,8 @@ ENV variables:
 - `QASE_RUN_NAME` - Set custom run name when no run ID is provided
 - `QASE_DEBUG` - If passed something - will enable debug logging for listener
 - `QASE_RUN_COMPLETE` - Will complete run after all tests are finished
+- `QASE_STEPS_RESULTS` - Will disable the reporting of results for each steps and hence will not show the warnings for testcase steps name mismatch. Overall testcase status shall be updated
+- `QASE_SCREENSHOT_PATH` - To fetch the latest screenshot and upload in failed testcase (Prerequisite: screenshot folder should be configured in selenium library)
 ### Usage:
 ```
 QASE_API_TOKEN=<API TOKEN> QASE_PROJECT=PRJCODE robot --listener qaseio.robotframework.Listener keyword_driven.robot data_driven.robot
@@ -89,7 +91,11 @@ qase_run_id=run_id
 qase_run_name=New Robot Framework Run
 qase_debug=True
 qase_run_complete=True
+qase_steps_results=True
+qase_screenshot_path=D:\\rf-demo\\results\\screenshots
 ```
+> Note: Please add proper slashes for the folder path depending on operating system
+
 Execution:
 ```
 robot --listener qaseio.robotframework.Listener someTest.robot


### PR DESCRIPTION
Added below functionalities:
- Added option to disable the reporting of results for each steps and hence will not show the warnings for testcase steps name mismatch. Overall testcase status shall be updated
- Added filename, line number in stack trace
- Added option to upload attachments to update in each test result in case of failure. Prerequisite for this functionality to work is to have a screenshot folder, setup when calling SeleniumLibrary from RobotFramework so as to pick the latest file assuming a screenshot was saved when testcase failed
- Added option to bypass the keywords which has nested keyword in it [NEED REVIEW]
 for example if there are nested keywords, then step mismatch issue will always be shown
```
Test with valid login
    [Documentation]  To check if user is able to logged in with valid credentials
    [Tags]  ValidLogin  Q-11
    Open Browser    https://www.phptravels.net/admin    chrome
    Maximize Browser Window
    Enter User Name    admin      
    Enter Password     admin
    Click on Submit button
    [Teardown]  Close Browser
```
So here `Enter User Name`, `Enter Password`, `Click on Submit button` in turn have different keywords which will show mismatch warning since those are not present in TMS