### PR TITLE
pytest-xdist issue fix

### DIFF
--- a/qase-pytest/README.md
+++ b/qase-pytest/README.md
@@ -25,6 +25,8 @@ and using command-line arguments:
                         Project code in Qase TestOps
   --qase-to-run=QS_TO_RUN_ID
                         Test Run ID in Qase TestOps
+  --qase-to-run-title=QS_TO_RUN_TITLE
+                        Define a custom title for Qase Test Run
   --qase-to-plan=QS_TO_PLAN_ID
                         Test Plan ID in Qase TestOps
   --qase-to-complete-run
@@ -32,7 +34,7 @@ and using command-line arguments:
   --qase-to-mode=QS_TO_MODE
                         You can choose `sync` or `async` mode for results publication. Default: async
   --qase-to-host=QS_TO_HOST
-                        Qase TestOps Enterprise customers can set their own hosts. Default: https://api.qase.io/v1
+                        Qase TestOps Enterprise customers can set their own hosts. Default: https://api.qase.io/v1/
 ```
 
 * INI file parameters:
@@ -40,13 +42,15 @@ and using command-line arguments:
 ```
   qs_mode (string):     default value for --qase-mode
   qs_environment (string):
-                        default value for --qase-environmet
+                        default value for --qase-environment
   qs_to_api_token (string):
                         default value for --qase-to-api-token
   qs_to_project_code (string):
                         default value for --qase-to-project
   qs_to_run_id (string):
                         default value for --qase-to-run
+  qs_to_run_title (string):
+                        default value for --qase-to-run-title
   qs_to_plan_id (string):
                         default value for --qase-to-plan
   qs_to_complete_run (bool):
@@ -74,7 +78,7 @@ def test_example_1():
 
 Each unique number can only be assigned once to the class or function being used.
 
-### Possible cases statuses
+### Possible test result statuses
 
 - PASSED - when test passed
 - FAILED - when test failed with AssertionError

--- a/qase-pytest/requirements.txt
+++ b/qase-pytest/requirements.txt
@@ -17,7 +17,7 @@ pytest==7.1.2
 pytest-cov==3.0.0
 python-dateutil==2.8.2
 pytzdata==2020.1
-qaseio==3.0.0
+qaseio==3.1.0
 requests==2.28.1
 six==1.16.0
 tomli==2.0.1

--- a/qase-pytest/src/qaseio/pytest/conftest.py
+++ b/qase-pytest/src/qaseio/pytest/conftest.py
@@ -2,6 +2,8 @@ from qaseio.pytest.plugin import QasePytestPlugin, QasePytestPluginSingleton
 
 from qaseio.pytest.testops import TestOps
 
+import os
+
 
 def get_option_ini(config, name):
     ret = config.getoption(name)  # 'default' arg won't work as expected
@@ -102,11 +104,13 @@ def pytest_configure(config):
             complete_run=get_option_ini(config, "qs_to_complete_run"),
             mode=get_option_ini(config, "qs_to_mode"),
             run_title=get_option_ini(config, "qs_to_run_title"),
-            host=get_option_ini(config, "qs_to_host")
+            host=get_option_ini(config, "qs_to_host"),
+            environment=get_option_ini(config, "qs_environment")
         )
 
         QasePytestPluginSingleton.init(
-            reporter=reporter
+            reporter=reporter,
+            xdist_enabled=is_xdist_enabled(config)
         )
         config.qaseio = QasePytestPluginSingleton.get_instance()
         config.pluginmanager.register(
@@ -114,6 +118,10 @@ def pytest_configure(config):
             name="qase-pytest",
         ) 
 
+def is_xdist_enabled(config):
+    if (config.pluginmanager.getplugin("xdist") is not None and os.getenv('PYTEST_XDIST_WORKER_COUNT') is not None):
+        return True
+    return False
 
 def pytest_unconfigure(config):
     qaseio = getattr(config, "src", None)

--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -43,7 +43,8 @@ class QasePytestPlugin:
 
     def __init__(
             self,
-            reporter
+            reporter,
+            xdist_enabled = False
     ):
         self.reporter = reporter
         self.result = {}
@@ -51,6 +52,7 @@ class QasePytestPlugin:
         self.steps = {}
         self.step_uuid = None
         self.run_id = None
+        self.xdist_enabled = xdist_enabled
 
     def start_step(self, uuid):
         now = time.time()
@@ -84,7 +86,7 @@ class QasePytestPlugin:
             QasePytestPlugin.meta_run_file.unlink()
 
     def pytest_sessionstart(self, session):
-        if is_xdist_controller(session):
+        if (not self.xdist_enabled) or (self.xdist_enabled and is_xdist_controller(session)):
             self.run_id = self.reporter.start_run()
             with FileLock("qaseio.lock"):
                 if self.run_id:
@@ -95,7 +97,7 @@ class QasePytestPlugin:
 
     def pytest_sessionfinish(self, session, exitstatus):
         self.reporter.finish()
-        if is_xdist_controller(session):
+        if (not self.xdist_enabled) or (self.xdist_enabled and is_xdist_controller(session)):
             self.reporter.complete_run()
             QasePytestPlugin.drop_run_id()
 


### PR DESCRIPTION
 - Fixed issue when qase-pytest-reporter couldn't be run when xdist is installed, but wasn't enabled.
 - Fixed an issue with environment id variable