### PR TITLE
Fixed ssl error by providing ssl context to the OpenAPI client configuration

### DIFF
--- a/qase-python-commons/setup.cfg
+++ b/qase-python-commons/setup.cfg
@@ -23,6 +23,7 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
+    certifi
     qaseio>=3.2.1
     attrs>=19.3.0
 python_requires = >=3.7

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -15,8 +15,9 @@ from datetime import datetime
 from typing import Tuple, Union
 import mimetypes
 import ntpath
+import certifi
 
-from io import BytesIO 
+from io import BytesIO
 
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -32,7 +33,7 @@ class TestOpsRunNotFoundException(Exception):
 
 class QaseTestOps:
 
-    def __init__(self, 
+    def __init__(self,
             api_token,
             project_code,
             run_id=None,
@@ -42,13 +43,14 @@ class QaseTestOps:
             environment=None,
             host="qase.io",
             complete_run=False) -> None:
-        
+
         configuration = Configuration()
         configuration.api_key['TokenAuth'] = api_token
         configuration.host = f'https://api.{host}/v1'
+        configuration.ssl_ca_cert = certifi.where()
 
         self.client = ApiClient(configuration)
-        
+
         self.project_code = project_code
         self.run_id = int(run_id) if run_id else run_id
         self.plan_id = plan_id
@@ -57,7 +59,7 @@ class QaseTestOps:
         self.environment = int(environment) if environment else environment
         self.host = host
         self.enabled = True
-        
+
         if run_title and run_title != '':
             self.run_title = run_title
         else:
@@ -93,16 +95,16 @@ class QaseTestOps:
                 for files in result.get('attachments', []):
                     attached.extend(self._upload(self.project_code, files))
                     result['attachments'] = [attach.hash for attach in attached]
-                    
+
                 steps = []
                 for step in result['steps']:
                     prepared = self._prepare_step(step)
                     steps.append(prepared)
-                        
+
                 result['steps'] = steps
 
                 results.append(result)
-            
+
 
             api_results = ResultsApi(self.client)
             print()
@@ -133,7 +135,7 @@ class QaseTestOps:
                 print(f"Run ID:{self.run_id} was finished successfully")
             except Exception as e:
                 print(f"Run ID:{self.run_id} was finished with error: {e}")
-    
+
     def _check_run(self):
         if self.enabled:
             if self.run_id and self.plan_id:
@@ -143,7 +145,7 @@ class QaseTestOps:
             if self.plan_id:
                 api_plans = PlansApi(self.client)
                 plan = api_plans.get_plan(
-                    code=self.project_code, 
+                    code=self.project_code,
                     id=int(self.plan_id)
                 )
                 if not plan:
@@ -189,7 +191,7 @@ class QaseTestOps:
                 )
                 self.run_id = result.result.id
                 self.run = result.result
-                
+
                 print()
                 print(
                     "Qase TestOps: created test run "


### PR DESCRIPTION
This fixes the error:

```
INTERNALERROR> urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.qase.io', port=443): Max retries exceeded with url: /v1/project/SD (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)')))
```

Happens because the OpenApi client needs the path to updated certificates from CA installed locally passed in the configuration object as described here:

https://stackoverflow.com/a/73377241/12357392
