### PR TITLE
fix ApiTypeError

### DIFF
--- a/qase-pytest/src/qaseio/pytest/conftest.py
+++ b/qase-pytest/src/qaseio/pytest/conftest.py
@@ -68,7 +68,8 @@ def pytest_configure(config):
                         api_token=config.getoption("qase_testops_api_token"),
                         host=config.getoption("qase_testops_api_host", "qase.io"),
                     )
-                    execution_plan = loader.load(config.getoption("qase_testops_project"), config.getoption("qase_testops_plan_id"))
+                    execution_plan = loader.load(config.getoption("qase_testops_project"),
+                                                 int(config.getoption("qase_testops_plan_id")))
 
                 reporter = QaseTestOps(
                     api_token=config.getoption("qase_testops_api_token"),


### PR DESCRIPTION
`TestOpsPlanLoader.load` expects `id` to be `int`, but it is called from conftest with `config.getoption("qase_testops_plan_id")` which provides string if the parameter is set in CLI. There should be an explicit type conversion between these two, otherwise there's an ApiTypeError