### PR TITLE
[qase-pytest] Send @qase.suite value with test result.

### DIFF
--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -6,6 +6,7 @@ import re
 
 from qaseio.commons.models.result import Result, Field
 from qaseio.commons.models.attachment import Attachment
+from qaseio.commons.models.suite import Suite
 from qaseio.commons.utils import QaseUtils
 from qaseio.commons.models.runtime import Runtime
 
@@ -164,6 +165,7 @@ class QasePytestPlugin:
         self._set_muted(item)
         self._set_testops_id(item)
         self._set_params(item)
+        self._set_suite(item)
 
     def finish_pytest_item(self, item):
         self.runtime.result.execution.complete()
@@ -267,6 +269,12 @@ class QasePytestPlugin:
         if hasattr(item, 'callspec'):
             for key, val in item.callspec.params.items():
                 self.runtime.result.add_param(key, str(val))
+
+    def _set_suite(self, item) -> None:
+        marker = item.get_closest_marker("qase_suite")
+        if marker:
+            self.runtime.suite = Suite(marker.kwargs.get("title"), marker.kwargs.get("description"))
+
 
 class QasePytestPluginSingleton:
     _instance = None

--- a/qase-python-commons/src/qaseio/commons/models/result.py
+++ b/qase-python-commons/src/qaseio/commons/models/result.py
@@ -3,6 +3,7 @@ import time
 import uuid
 import json
 from qaseio.commons.models.step import Step
+from qaseio.commons.models.suite import Suite
 from qaseio.commons.models.relation import Relation
 from qaseio.commons.models.attachment import Attachment
 from qaseio.commons.utils import QaseUtils
@@ -75,6 +76,7 @@ class Result(object):
         self.relations: List[Type[Relation]] = []
         self.muted: bool = False
         self.message: Optional[str] = None
+        self.suite: Optional[Type[Suite]] = None
         QaseUtils.get_host_data()
 
     def add_message(self, message: str) -> None:
@@ -98,6 +100,9 @@ class Result(object):
     def add_relation(self, relation: Type[Relation]) -> None:
         self.relations.append(relation)
 
+    def add_suite(self, suite: Type[Suite]) -> None:
+        self.suite = suite
+
     def get_status(self) -> Optional[str]:
         return self.execution.status
     
@@ -120,7 +125,11 @@ class Result(object):
     
     def get_duration(self) -> int:
         return self.execution.duration
-    
+
+    def get_suite_title(self) -> Optional[str]:
+        if self.suite:
+            return self.suite.title
+
     def set_run_id(self, run_id: str) -> None:
         self.run_id = run_id
 

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -136,6 +136,9 @@ class QaseTestOps:
                 if (result.get_field('layer')):
                     case_data["layer"] = result.get_field('layer')
 
+                if result.get_suite_title():
+                    case_data["suite_title"] = "\t".join(result.get_suite_title().split("."))
+
                 results.append({
                     "case_id": result.get_testops_id(),
                     "status": result.execution.status,
@@ -324,6 +327,9 @@ class QaseTestOps:
 
             if (result.get_field('layer')):
                 case_data["layer"] = result.get_field('layer')
+
+            if result.get_suite_title():
+                case_data["suite_title"] = "\t".join(result.get_suite_title().split("."))
 
             try:
                 api_results.create_result(


### PR DESCRIPTION
`qase.suite` is present but it is not used anywhere. In this PR `Suite` object is created (passing suite title and optional description from decorator) and assigned to `Result` object, so later it can be used when sending results to Qase. [create-result](https://developers.qase.io/reference/create-result) does not allow to specify description, so only title is actually sent.

Fixes #131