### PR TITLE
[qase-pytest] Fix typo that prevented @qase.suite from actually working.

### DIFF
--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -273,7 +273,7 @@ class QasePytestPlugin:
     def _set_suite(self, item) -> None:
         marker = item.get_closest_marker("qase_suite")
         if marker:
-            self.runtime.suite = Suite(marker.kwargs.get("title"), marker.kwargs.get("description"))
+            self.runtime.result.suite = Suite(marker.kwargs.get("title"), marker.kwargs.get("description"))
 
 
 class QasePytestPluginSingleton:


### PR DESCRIPTION
Suite data was saved inside of `runtime` object  instead of `runtime.result` so it was ignored and lost.