### PR TITLE
Release qase-python-commons 2.0.5 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to the project
+
+## Making a package release
+
+To release a new package version:
+
+1.  Update the package's version in `pyproject.toml`:
+
+    ```toml
+    [project]
+    name = "qase-python-commons"
+    version = "2.42.1"
+    ```
+    
+2.  Open & merge a pull request, as usual.
+3.  After merging to a stable branch, tag the commit with `qase-{packagename}-{version}`, for example:
+
+    ```sh
+    git tag qase-python-commons-2.42.1
+    git push --follow-tags
+    ```

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "2.0.4"
+version = "2.0.5"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]


### PR DESCRIPTION
# Release qase-python-commons 2.0.5 

Contains one bugfix.

Resolves https://github.com/qase-tms/qase-python/issues/156

# docs: describe the release process