### PR TITLE
Fixed receiving environment from Qase

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "2.0.5"
+version = "2.0.6"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -90,7 +90,7 @@ class QaseTestOps:
             api_instance = EnvironmentsApi(self.client)
             response = api_instance.get_environments(code=project)
             if hasattr(response, 'result'):
-                for env in response["result"]["entities"]:
+                for env in response.result.entities:
                     if env["slug"] == environment:
                         return env["id"]
         return None


### PR DESCRIPTION
Fixed this issue:
`INTERNALERROR>   File "/Users/gda/PycharmProjects/PytestExamples/.venv/lib/python3.9/site-packages/qaseio/commons/testops.py", line 60, in __init__
INTERNALERROR>     self.environment = self._get_environment(environment, self.project_code)
INTERNALERROR>   File "/Users/gda/PycharmProjects/PytestExamples/.venv/lib/python3.9/site-packages/qaseio/commons/testops.py", line 93, in _get_environment
INTERNALERROR>     for env in response["result"]["entities"]:
INTERNALERROR> TypeError: 'EnvironmentListResponse' object is not subscriptable
`