### PR TITLE
docs: update contributing instruction on git tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ To release a new package version:
 3.  After merging to a stable branch, tag the commit with `qase-{packagename}-{version}`, for example:
 
     ```sh
+    git checkout master
+    git pull
     git tag qase-python-commons-2.42.1
-    git push --follow-tags
+    git push origin qase-python-commons-2.42.1
     ```


### PR DESCRIPTION
Using `git push origin tagname` is the safest option. Unlike it, `git push --tags` can result in pushing all present tags, including some temporary or stale tags.