### PR TITLE
Fix 'object is not subscriptable' in commons

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "2.0.8"
+version = "2.0.9"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -91,8 +91,8 @@ class QaseTestOps:
             response = api_instance.get_environments(code=project)
             if hasattr(response, 'result'):
                 for env in response.result.entities:
-                    if env["slug"] == environment:
-                        return env["id"]
+                    if env.slug == environment:
+                        return env.id
         return None
 
     def _send_bulk_results(self):


### PR DESCRIPTION
Resolves the following error
 TypeError: 'Environment' object is not subscriptable

This error was caused by an update in qaseio client, changing the interface of the Environment object. Now qase-python-commons supports the new interface.