### PR TITLE
[do not merge] pytest: recovery release 5.0.4

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.11, '3.10', 3.9, 3.8, 3.7]
+        python-version: [3.11, '3.10', 3.9, 3.8]
         changed-dir: ["qaseio", "qase-pytest", "qase-robotframework", "qase-python-commons"]
     name: Project ${{ matrix.changed-dir }} - Python ${{ matrix.python-version }}
     steps:

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "5.0.5"
+version = "5.0.6"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -15,11 +15,11 @@ classifiers = [
     "Programming Language :: Python",
 ]
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-pytest"}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons>=2.0.9,<2.1.0",
-    "pytest>=8.0.0",
-    "filelock~=3.13.1",
+    "qase-python-commons>=2.0.11,<2.1.0",
+    "pytest>=7.4.4",
+    "filelock~=3.12.2",
     "more_itertools",
 ]
 
@@ -32,8 +32,8 @@ testing = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-minversion = 3.8
-envlist = py{38,39,310,311}
+minversion = 3.7
+envlist = py{37,38,39,310,311}
 
 [testenv]
 deps =

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -1,20 +1,87 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 79
-target-version = ['py37']
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.tox
-    | \.venv
-    | _build
-    | build
-    | dist
-  )/
-)
-'''
+[project]
+name = "qase-pytest"
+version = "5.0.4"
+description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
+readme = "README.md"
+authors = [{name = "Qase Team", email = "support@qase.io"}]
+license = {file = "LICENSE"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Pytest",
+    "Programming Language :: Python",
+]
+urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-pytest"}
+requires-python = ">=3.8"
+dependencies = [
+    "qase-python-commons>=2.0.9,<2.1.0",
+    "pytest>=8.0.0",
+    "filelock~=3.13.1",
+    "more_itertools",
+]
+
+[project.optional-dependencies]
+testing = [
+    "pytest",
+    "pytest-cov",
+]
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+minversion = 3.8
+envlist = py{38,39,310,311}
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+passenv =
+    HOME
+commands =
+    pytest --cov-config=pyproject.toml {posargs}
+extras =
+    all
+    testing
+"""
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "--cov-report=term-missing --verbose"
+norecursedirs = ["dist", "build", ".tox"]
+testpaths = ["tests"]
+
+[tool.flake8]
+exclude = [".tox", "build", "dist", ".eggs"]
+
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.paths]
+source = ["src/qaseio/pytest"]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "if self\\.debug",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+    ]
+
+ignore_errors = false

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "5.0.4"
+version = "5.0.5"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-pytest/src/qaseio/pytest/options.py
+++ b/qase-pytest/src/qaseio/pytest/options.py
@@ -101,7 +101,7 @@ class QasePytestOptions:
             parser,
             group,
             "--qase-testops-run-complete",
-            dest="qase_testops_run_description",
+            dest="qase_testops_run_complete",
             type="bool",
             default=False,
             help="Complete run after tests execution"


### PR DESCRIPTION
Release 5.0.3 contains changes incompatible with the latest versions of qaseio and qase-python-commons. This new version is released to be the latest one until we release a newer major version which makes the changes compatible.