### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,8 +13,8 @@ jobs:
         changed-dir: ["qaseio", "qase-pytest", "qase-robotframework", "qase-python-commons"]
     name: Project ${{ matrix.changed-dir }} - Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           list-files: 'shell'
@@ -23,7 +23,7 @@ jobs:
               - '${{ matrix.changed-dir }}/**'
       - name: Set up Python ${{ matrix.python-version }}
         if: steps.filter.outputs.changes == 'true'
-        uses: actions/setup-python@v2 
+        uses: actions/setup-python@v5 
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -45,10 +45,10 @@ jobs:
         prefix: [ "qaseio", "qase-pytest", "qase-robotframework", "qase-python-commons" ]
     if: startsWith(github.event.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
         if: contains(github.event.ref, matrix.prefix)
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install build dependencies


### PR DESCRIPTION
ci: update GitHub actions to use Node.js v20
--
Update actions/checkout and dorny/paths-filter to the latest versions, using Node.js v20.

This change removes the multiple warnings from the GitHub run view:

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, dorny/paths-filter@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

Update actions/setup-python to the latest version