### PR TITLE
pytest: use sane defaults in the config example

### DIFF
--- a/qase-pytest/README.md
+++ b/qase-pytest/README.md
@@ -37,21 +37,17 @@ All configuration options are listed in the following doc: [Configuration](docs/
 		}
 	},
 	"testops": {
-		"bulk": true,
+		"project": "YOUR_PROJECT_CODE",
 		"api": {
 			"token": "YOUR_API_TOKEN",
 			"host": "qase.io"
 		},
 		"run": {
-            "id": 1,
-			"title": "Test run title",
+			"title": "Automated test run",
 			"complete": true
 		},
-        "plan": {
-            "id": 1
-        },
-		"defect": true,
-		"project": "YOUR_PROJECT_CODE",
+		"defect": false,
+		"bulk": true,
 		"chunk": 200
 	},
 	"framework": {


### PR DESCRIPTION
* Projects don't have test plans upon creation, so using plan=1 results in an error or empty plan.
* Reporter should create a new test run by default, not reuse the same run=1.
* Creating defects from failed autotests is also undesired by default.