### PR TITLE
Optional reporting fields

### DIFF
--- a/qase-pytest/src/qaseio/pytest/plugin.py
+++ b/qase-pytest/src/qaseio/pytest/plugin.py
@@ -161,14 +161,15 @@ class QasePytestPlugin:
 
     def start_pytest_item(self, item):
         self.runtime.result = Result(
-            title = self._get_title(item), 
-            signature = self._get_signature(item),
+            signature=self._get_signature(item),
             )
+        self._set_testops_id(item)
+        self._set_title(item)
+        self._set_fields(item)
         self._set_fields(item)
         self._set_tags(item)
         self._set_author(item)
         self._set_muted(item)
-        self._set_testops_id(item)
         self._set_params(item)
         self._set_suite(item)
 
@@ -209,20 +210,15 @@ class QasePytestPlugin:
                     self.reporter.set_run_id(self.run_id)
                 except ValueError:
                     pass
-    
-    def _get_title(self, item):
-        title = None
+
+    def _set_title(self, item):
         try:
-            title = item.get_closest_marker("qase_title").kwargs.get("title")
+            self.runtime.result.add_title(item.get_closest_marker("qase_title").kwargs.get("title"))
         except:
             pass
 
-        if not title:
-            title = item.originalname
-
-        return str(title)
-    
-    def _get_signature(self, item) -> str:
+    @staticmethod
+    def _get_signature(item) -> str:
         return re.sub(r'\[.*?\]', '', item.nodeid)
     
     def _set_relations(self, item) -> None:

--- a/qase-python-commons/src/qaseio/commons/models/result.py
+++ b/qase-python-commons/src/qaseio/commons/models/result.py
@@ -62,14 +62,14 @@ class Request(object):
         self.response_body = response_body
 
 class Result(object):
-    def __init__(self, title: str, signature: str) -> None:
+    def __init__(self, signature: str) -> None:
         self.id: str = str(uuid.uuid4())
-        self.title: str = title
+        self.title: Optional[str] = None
         self.signature: str = signature
         self.run_id: Optional[str] = None
         self.testops_id: Optional[int] = None
         self.execution: Type[Execution] = Execution()
-        self.fields: Dict[Type[Field]] = {}
+        self.fields: Optional[Dict[Type[Field]]] = None
         self.attachments: List[Attachment] = []
         self.steps: List[Type[Step]] = []
         self.params: Optional[dict] = {}
@@ -109,11 +109,16 @@ class Result(object):
     
     def get_id(self) -> str:
         return self.id
-    
+
+    def add_title(self, title: str) -> None:
+        self.title = title
+
     def get_title(self) -> str:
         return self.title
-    
+
     def get_field(self, name: str) -> Optional[Type[Field]]:
+        if not self.fields:
+            return None
         if name in self.fields:
             return self.fields[name]
         return None

--- a/qase-python-commons/src/qaseio/commons/testops.py
+++ b/qase-python-commons/src/qaseio/commons/testops.py
@@ -88,52 +88,27 @@ class QaseTestOps:
                 print(
                     "[Qase] ⚠️  Disabling Qase TestOps reporter. Exception when calling ProjectApi->get_project: %s\n" % e)
 
+    @staticmethod
+    def _get_value(result, test_case, field_name, default=None):
+        if result.get_field(field_name):
+            return result.get_field(field_name)
+        elif test_case:
+            return getattr(test_case, field_name, default)
+        else:
+            return default
+
     def _get_case_info(self, result):
-        """
-        If result info is None, trying to retrieve it from server
-        Returns: test title, description, preconditions, postconditions
-        """
         if result.get_testops_id() != 0:
             api_cases = CasesApi(self.client)
             response = api_cases.get_case(code=self.project_code, id=result.get_testops_id())
-            if hasattr(response, 'result'):
-                test_case = response.result
-            else:
-                test_case = None
+            test_case = getattr(response, 'result', None)
         else:
             test_case = None
 
-        # getting title
-        if result.get_title():
-            title = result.get_title()
-        elif test_case:
-            title = test_case.title
-        else:
-            title = result.signature.split('::')[-1]
-
-        # Getting descriprion
-        if result.get_field('description'):
-            description = result.get_field('description')
-        elif test_case:
-            description = test_case.description
-        else:
-            description = None
-
-        # Getting preconditions
-        if result.get_field('preconditions'):
-            preconditions = result.get_field('preconditions')
-        elif test_case:
-            preconditions = test_case.preconditions
-        else:
-            preconditions = None
-
-        # Getting preconditions
-        if result.get_field('postconditions'):
-            postconditions = result.get_field('postconditions')
-        elif test_case:
-            postconditions = test_case.postconditions
-        else:
-            postconditions = None
+        title = self._get_value(result, test_case, 'title', result.signature.split('::')[-1])
+        description = self._get_value(result, test_case, 'description')
+        preconditions = self._get_value(result, test_case, 'preconditions')
+        postconditions = self._get_value(result, test_case, 'postconditions')
 
         return title, description, preconditions, postconditions
 


### PR DESCRIPTION
Make title, description, precondition and postcondition fields optional by default. 
If remains blank in tests - will try to retrieve it from server via testops_id,
if id is not present - sets default value (Node.Item.name for title, None for other fields),
if any of this fileds have bin marked in tests (via @qase.title for e.g.) it will be owerwriten with this value. 

This changes solves problem with clearing actual test names and descriptions in test repository when reporting from pytest without marking this data (for e.g. setting only qase_id)