### PR TITLE
qase-python-commons: fixed problem with rewrite fields

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "2.0.11"
+version = "2.0.12"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]


### PR DESCRIPTION
qase-python-commons: fixed problem with rewrite fields
--
If a test has qase ID then we skip fields like title, description, etc. 
If a test doesn't have qase ID then we assign fields like title, description, etc.