### PR TITLE
qase-pytest: update docs

### DIFF
--- a/qase-pytest/README.md
+++ b/qase-pytest/README.md
@@ -1,67 +1,70 @@
-# [Qase](https://qase.io) Pytest Plugin
+# [Qase TestOps](https://qase.io) Pytest Reporter
 
 [![License](https://lxgaming.github.io/badges/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Installation
 
-```
+```sh
 pip install qase-pytest
 ```
+
 ## Upgrade from 4.x to 5.x and to 6.x
-A new version of qase-pytest reporter has breaking changes. Follow these [guide](UPGRADE.md) that will help you to migrate to a new version.
+
+The new version 6.x of the Pytest reporter has breaking changes.
+To migrate from versions 4.x or 5.x, follow the [upgrade guide](UPGRADE.md).
 
 ## Configuration
 
-Qase Pytest Plugin can be configured in multiple ways:
- - using a config file `qase.config.json`
- - using environment variables
- - using CLI options
+Qase Pytest Reporter is configured in multiple ways:
 
-All configuration options are listed in the following doc: [Configuration](../README.md#configuration).
+- using a config file `qase.config.json`
+- using environment variables
+- using command line options
+
+Environment variables override the values given in the config file, 
+and command line options override both other values.
+
+Configuration options are described in the
+[configuration reference](docs/CONFIGURATION.md).
 
 
 ### Example: qase.config.json
 
-```
+```json
 {
-	"mode": "testops", 
-	"fallback": "report",
-	"report": {
-		"driver": "local",
-		"connection": {
-			"local": {
-				"path": "./build/qase-report",
-				"format": "json" 
-			}
-		}
-	},
-	"testops": {
-		"bulk": true,
-		"api": {
-			"token": "YOUR_API_TOKEN",
-			"host": "qase.io"
-		},
-		"run": {
-            "id": 1,
-			"title": "Test run title",
-			"complete": true
-		},
-        "plan": {
-            "id": 1
-        },
-		"defect": true,
-		"project": "YOUR_PROJECT_CODE",
-		"chunk": 200
-	},
-	"framework": {
-		"pytest": {
-			"capture": {
-				"logs": true,
-				"http": true
-			}
-		}
-	},
-	"environment": "local"
+  "mode": "testops", 
+  "fallback": "report",
+  "testops": {
+    "project": "YOUR_PROJECT_CODE",
+    "api": {
+      "token": "YOUR_API_TOKEN",
+      "host": "qase.io"
+    },
+    "run": {
+      "title": "Test run title"
+    },
+    "batch": {
+      "size": 100
+    }
+  },
+    "report": {
+    "driver": "local",
+    "connection": {
+      "local": {
+        "path": "./build/qase-report",
+        "format": "json" 
+      }
+    }
+  },
+  "framework": {
+    "pytest": {
+      "capture": {
+        "logs": true,
+        "http": true
+      }
+    }
+  },
+  "environment": "local"
 }
 ```
 
@@ -69,7 +72,9 @@ All configuration options are listed in the following doc: [Configuration](../RE
 
 ### Link tests with test cases in Qase TestOps
 
-To link tests in code with tests in Qase TestOps you can use predefined decorators:
+To link the automated tests with the test cases in Qase TestOps, use the `@qase.id()` decorator.
+Other test data, such as case title, system and custom fields,
+can be added with `@qase.title()` and `@qase.fields()`:
 
 ```python
 from qase.pytest import qase
@@ -90,7 +95,8 @@ def test_example_1():
 Each unique number can only be assigned once to the class or function being used.
 
 ### Ignore a particular test
-If you want to exclude a particular test from the report, you can use the `@qase.ignore` decorator:
+
+To exclude a particular test from the report, use the `@qase.ignore` decorator:
 
 ```python
 from qase.pytest import qase
@@ -103,71 +109,58 @@ def test_example_1():
 ### Possible test result statuses
 
 - PASSED - when test passed
-- FAILED - when test failed with AssertionError
+- FAILED - when test failed with `AssertionError`
 - BLOCKED - when test failed with any other exception
 - SKIPPED - when test has been skipped
 
 ### Capture network logs
-In order to capture network logs, you need to enable the `http` option in the `capture` section of the `framework` section in the config file.
 
-The Qase Pytest reporter will capture all requests and responses and save as a test step automatically.
+To capture the network logs, enable the `http` option in the `framework.capture` section
+of the configuration file.
+
+The Qase Pytest reporter will capture all HTTP requests and responses
+and save them as a test steps automatically.
 
 ### Add attachments to test results
 
-When you need to push some additional information to the server you could use
-attachments:
+To upload screenshots, logs, and other information to Qase.io,
+use `qase.attach()`.
+It works both with files in the filesystem and with data available in the code.
+There is no limit on the amount of attachments from a single test.
 
 ```python
 import pytest
 from qase.pytest import qase
 
-@pytest.fixture(scope="session")
-def driver():
-    driver = webdriver.Chrome()
-    yield driver
-    logs = "\n".join(str(row) for row in driver.get_log('browser')).encode('utf-8')
-    qase.attach((logs, "text/plain", "browser.log"))
-    driver.quit()
-
-@qase.title("My first test")
+@qase.title("File attachments")
 def test_example_1():
+    # attach files from the filesystem:
     qase.attach("/path/to/file", "/path/to/file/2")
+    # to add multiple attachments, pass them in tuples:
     qase.attach(
         ("/path/to/file/1", "application/json"),
         ("/path/to/file/3", "application/xml"),
     )
 
-@qase.id(12)
-def test_example_2(driver):
-    qase.attach((driver.get_screenshot_as_png(), "image/png", "result.png"))
-```
-
-You can pass as many files as you need.
-
-**Note:** If no case ID is associated with the current test in pytest,
-the attachment will not be uploaded:
-
-```python
-import pytest
-from qase.pytest import qase
-
 @pytest.fixture(scope="session")
 def driver():
     driver = webdriver.Chrome()
     yield driver
     logs = "\n".join(str(row) for row in driver.get_log('browser')).encode('utf-8')
-    # This would do nothing, because last test does not have case id link
+    # attach logs from a code variable as a text file:
     qase.attach((logs, "text/plain", "browser.log"))
     driver.quit()
 
+@qase.id(12)
 def test_example_2(driver):
-    # This would do nothing
+    # attach the output of driver.get_screenshot_as_png() as a png image
     qase.attach((driver.get_screenshot_as_png(), "image/png", "result.png"))
 ```
 
 ### Linking code with steps
 
-It is possible to link the test step using a function, or using context.
+To mark a test step, either annotate a function with `@qase.step()`,
+or use the `with qase.step()` context:
 
 ```python
 from qase.pytest import qase
@@ -180,7 +173,7 @@ def some_step():
 def another_step():
     sleep(3)
 
-...
+# ...
 
 def test_example():
     some_step()
@@ -190,16 +183,38 @@ def test_example():
         sleep(1)
 ```
 
-### Sending tests to existing testrun
+### Creating new testrun according to current pytest run
 
-Testrun in TestOps will contain only those test results, which are presented in testrun,
-but every test would be executed.
+By default, qase-pytest will create a new test run in Qase TestOps
+and report results to this test run.
+To provide a custom name for this run, add
+the option `--qase-testops-run-title`.
 
 ```bash
 pytest \
     --qase-mode=testops \
     --qase-testops-api-token=<your api token here> \
-    --qase-testops-project=PRJCODE \ # project, where your testrun exists in
+    --qase-testops-project=PRJCODE \ # project, where your testrun would be created
+    --qase-testops-run-title=My\ First\ Automated\ Run
+```
+
+### Sending tests to existing testrun
+
+Test results can be reported to an existing test run in Qase using its ID.
+This is useful when a test run combines tests from multiple sources:
+
+* manual and automated
+* autotests from different frameworks
+* tests running in multiple shards on different machines
+
+For example, if the test run has ID=3, the following command will
+run tests and report results to this test run:
+
+```bash
+pytest \
+    --qase-mode=testops \
+    --qase-testops-api-token=<your api token here> \
+    --qase-testops-project=PRJCODE \ # project, where the test run is created
     --qase-testops-run-id=3 # testrun id
 ```
 
@@ -214,18 +229,4 @@ pytest \
     --qase-testops-api-token=<your api token here> \
     --qase-testops-project=PRJCODE \ # project, where your testrun exists in
     --qase-testops-plan-id=3 # testplan id
-```
-
-### Creating new testrun according to current pytest run
-
-If you want to create a new test run in Qase TestOps for each execution, you can simply 
-skip `--qase-testops-run` option. If you want to provide a custom name for this run, you can add
-the option `--qase-testops-run-title`.
-
-```bash
-pytest \
-    --qase-mode=testops \
-    --qase-testops-api-token=<your api token here> \
-    --qase-testops-project=PRJCODE \ # project, where your testrun would be created
-    --qase-testops-run-title=My\ First\ Automated\ Run
 ```

--- a/qase-pytest/docs/CONFIGURATION.md
+++ b/qase-pytest/docs/CONFIGURATION.md
@@ -1,35 +1,43 @@
 # Qase Pytest Plugin configuration
 
-Qase Pytest Plugin can be configured in multiple ways:
- - using a config file `qase.config.json`
- - using environment variables
- - using CLI options
+Qase Pytest Reporter is configured in multiple ways:
 
-All configuration options are listed in the table below:
-| Description | Config file | Environment variable | CLI option | Default value | Required | Possible values |
-| --- | --- | --- | --- | --- | --- | --- |
-| **Common** |
-| Mode of reporter | `mode` | `QASE_MODE` | `--qase-mode` | `testops` | No | `testops`, `report`, `off` |
-| Fallback mode | `fallback` | `QASE_FALLBACK` | `--qase-fallback` | `report` | No | `report`, `off` |
-| Environment | `environment` | `QASE_ENVIRONMENT` | `--qase-environment` | `local` | No | Any string |
-| Execution plan path | `execution_plan_path` | `QASE_EXECUTION_PLAN_PATH` | `--qase-execution-plan-path` | `./build/qase-execution-plan.json` | No | Any string |
-| **Qase Report configuration** |
-| Report driver | `report.driver` | `QASE_REPORT_DRIVER` | `--qase-report-driver` | `local` | No | `local` |
-| Local path to store report | `report.connection.path` | `QASE_REPORT_CONNECTION_PATH` | `--qase-report-connection-path` | `./build/qase-report` | No | Any string |
-| Report format | `report.connection.format` | `QASE_REPORT_CONNECTION_FORMAT` | `--qase-report-connection-format` | `json` | No | `json`, `jsonp` |
-| **Qase TestOps configuration** |
-| TestOps API token | `testops.api.token` | `QASE_TESTOPS_API_TOKEN` | `--qase-testops-api-token` |  | Yes | Any string |
-| TestOps API host | `testops.api.host` | `QASE_TESTOPS_API_HOST` | `--qase-testops-api-host` | `qase.io` | No | Any string |
-| TestOps project code | `testops.project` | `QASE_TESTOPS_PROJECT` | `--qase-testops-project` |  | Yes | Any string |
-| TestOps test run ID | `testops.run.id` | `QASE_TESTOPS_RUN_ID` | `--qase-testops-run-id` |  | No | Any integer |
-| TestOps test run title | `testops.run.title` | `QASE_TESTOPS_RUN_TITLE` | `--qase-testops-run-title` |  | No | Any string |
-| TestOps test run description | `testops.run.description` | `QASE_TESTOPS_RUN_DESCRIPTION` | `--qase-testops-run-description` |  | No | Any string |
-| TestOps test run complete | `testops.run.complete` | `QASE_TESTOPS_RUN_COMPLETE` | `--qase-testops-run-complete` | `True` | No | `true`, `false` |
-| TestOps test plan ID | `testops.plan.id` | `QASE_TESTOPS_PLAN_ID` | `--qase-testops-plan-id` |  | No | Any integer |
-| Execution chunk size | `testops.chunk` | `QASE_TESTOPS_CHUNK` | `--qase-testops-chunk` | `200` | No | Any integer |
-| TestOps defect | `testops.defect` | `QASE_TESTOPS_DEFECT` | `--qase-testops-defect` | `True` | No | `true`, `false` |
-| TestOps bulk | `testops.bulk` | `QASE_TESTOPS_BULK` | `--qase-testops-bulk` | `True` | No | `true`, `false` |
-| **Framework specific options** |
-| **Pytest** |
-| Capture logs | `pytest.capture_logs` | `QASE_PYTEST_CAPTURE_LOGS` | `--qase-pytest-capture-logs` | `False` | No | `true`, `false` |
-| Capture HTTP traffic | `pytest.capture_http` | `QASE_PYTEST_CAPTURE_HTTP` | `--qase-pytest-capture-http` | `False` | No | `true`, `false` |
+- using a config file `qase.config.json`
+- using environment variables
+- using command line options
+
+Environment variables override the values given in the config file, 
+and command line options override both other values.
+
+## Configuration options
+
+| Description                                    | Config file                | Environment variable            | CLI option                        | Default value                           | Required | Possible values            |
+|------------------------------------------------|----------------------------|---------------------------------|-----------------------------------|-----------------------------------------|----------|----------------------------|
+| **Common**                                     |
+| Main reporting mode                            | `mode`                     | `QASE_MODE`                     | `--qase-mode`                     | `testops`                               | No       | `testops`, `report`, `off` |
+| Fallback reporting mode                        | `fallback`                 | `QASE_FALLBACK`                 | `--qase-fallback`                 | `report`                                | No       | `testops`, `report`, `off` |
+| Execution plan path                            | `execution_plan_path`      | `QASE_EXECUTION_PLAN_PATH`      | `--qase-execution-plan-path`      | `./build/qase-execution-plan.json`      | No       | Any string                 |
+| **Qase TestOps mode configuration**            |
+| Qase project code                              | `testops.project`          | `QASE_TESTOPS_PROJECT`          | `--qase-testops-project`          |                                         | Yes      | Any string                 |
+| Qase API token                                 | `testops.api.token`        | `QASE_TESTOPS_API_TOKEN`        | `--qase-testops-api-token`        |                                         | Yes      | Any string                 |
+| Qase API host                                  | `testops.api.host`         | `QASE_TESTOPS_API_HOST`         | `--qase-testops-api-host`         | `qase.io`                               | No       | Any string                 |
+| Title of the Qase test run                     | `testops.run.title`        | `QASE_TESTOPS_RUN_TITLE`        | `--qase-testops-run-title`        | `Automated Run {current date and time}` | No       | Any string                 |
+| Description of the Qase test run               | `testops.run.description`  | `QASE_TESTOPS_RUN_DESCRIPTION`  | `--qase-testops-run-description`  | None, leave empty                       | No       | Any string                 |
+| Create test run using a test plan              | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `--qase-testops-plan-id`          | None, don't use plans for the test run  | No       | Any integer                |
+| Complete test run after running tests          | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `--qase-testops-run-complete`     | `True`                                  | No       | `true`, `false`            |
+| ID of the Qase test run to report results      | `testops.run.id`           | `QASE_TESTOPS_RUN_ID`           | `--qase-testops-run-id`           | None, create a new test run             | No       | Any integer                |
+| Batch size for uploading test results          | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `--qase-testops-batch-size`       | 200                                     | No       | 1 to 2000                  |
+| Create defects in Qase                         | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `--qase-testops-defect`           | `False`, don't create defects           | No       | `True`, `False`            |
+| Qase environment                               | `environment`              | `QASE_ENVIRONMENT`              | `--qase-environment`              | `local`                                 | No       | Any string                 |
+| **Qase Report mode configuration**             |
+| Local path to store report                     | `report.connection.path`   | `QASE_REPORT_CONNECTION_PATH`   | `--qase-report-connection-path`   | `./build/qase-report`                   | No       | Any string                 |
+| Report format                                  | `report.connection.format` | `QASE_REPORT_CONNECTION_FORMAT` | `--qase-report-connection-format` | `json`                                  | No       | `json`, `jsonp`            |
+| Driver used for report mode                    | `report.driver`            | `QASE_REPORT_DRIVER`            | `--qase-report-driver`            | `local`                                 | No       | `local`                    |
+| **Framework specific options**                 |
+| **Pytest**                                     |
+| Capture logs                                   | `pytest.capture_logs`      | `QASE_PYTEST_CAPTURE_LOGS`      | `--qase-pytest-capture-logs`      | `False`                                 | No       | `true`, `false`            |
+| Capture HTTP traffic                           | `pytest.capture_http`      | `QASE_PYTEST_CAPTURE_HTTP`      | `--qase-pytest-capture-http`      | `False`                                 | No       | `true`, `false`            |
+| **Earlier versions**                           |
+| **qase-pytest v5.x**                           |
+| TestOps bulk (always on since v6)              | `testops.bulk`             | `QASE_TESTOPS_BULK`             | `--qase-testops-bulk`             | `True`                                  | No       | `true`, `false`            |
+| Execution chunk size (changed to `batch.size`) | `testops.chunk`            | `QASE_TESTOPS_CHUNK`            | `--qase-testops-chunk`            | 200                                     | No       | 1 to 2000                  |

--- a/qase-pytest/docs/UPGRADE.md
+++ b/qase-pytest/docs/UPGRADE.md
@@ -1,5 +1,28 @@
 # Upgrade guides
 
+## From 5.x to 6.x
+
+### Bulk uploading results has changed
+
+In v5, two configuration options defined how the reporter was uploading results to Qase:
+`testops.bulk` and `testops.chunk`.
+
+In v6, reporter always sends results in portions, called batches.
+Default batch size is 200, and can be set to anything from 1 to 2000.
+Update the config in the following way:
+
+```diff
+{
+  "testops": {
+-   "bulk": true, 
+-   "chunk": 100
++   "batch": {
++     "size": 100
++   }
+  }
+}
+```
+
 ## From 4.x to 5.x
 
 ### Configuration

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -33,7 +33,7 @@ class QaseTestOps:
         self.run_id = int(run_id) if run_id else run_id
         self.plan_id = int(plan_id) if plan_id else plan_id
         self.defect = self.config.get('testops_defect', False, bool)
-        self.complete_after_run = self.config.get('testops.run.complete', False, bool)
+        self.complete_after_run = self.config.get('testops.run.complete', True, bool)
         self.environment = None
 
         self.batch_size = min(2000, max(1, int(self.config.get('testops.batch.size', DEFAULT_BATCH_SIZE))))
@@ -253,6 +253,7 @@ class QaseTestOps:
         return False
 
     def _create_run(self, plan_id=None, environment_id=None, cases: List = []) -> None:
+        # TODO: read description from configs
         kwargs = dict(
             title=self.run_title,
             cases=cases,


### PR DESCRIPTION
# qase-pytest: update docs

* Update code examples, remove the wrong info about attachments not uploaded.
* Put the example with creating a test run in Qase first, because it's the
  first option to try and the most popular one.
* Update the Configuration table: rewrite descriptions, update and explain default values.
* Start the v5 to v6 migration guide.
* Update grammar, style, and formatting in multiple places.

# qase-pytest-commons: complete runs by default 