### PR TITLE
release: qase-python-commons 3.0.2b2

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.7"
 dependencies = [
     "certifi>=2024.2.2",
     "attrs>=23.2.0",
-    "qaseio==4.0.2",
+    "qase-api-client~=1.0.0b2",
     "more_itertools"
 ]
 

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b1"
+version = "3.0.2b2"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/requirements.txt
+++ b/qase-python-commons/requirements.txt
@@ -2,4 +2,4 @@ attrs==23.2.0
 certifi>=2024.2.2
 more-itertools==9.1.0
 pip~=24.0
-qaseio~=4.0.2
+qase-api-client~=1.0.0b2

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -1,9 +1,9 @@
 from typing import Dict, Union
 
 import certifi
-from qaseio import ApiClient, ProjectsApi, Project, EnvironmentsApi, RunsApi, AttachmentsApi, \
+from qase.api_client_v1 import ApiClient, ProjectsApi, Project, EnvironmentsApi, RunsApi, AttachmentsApi, \
     AttachmentGet, RunCreate, ResultsApi, ResultcreateBulk
-from qaseio.configuration import Configuration
+from qase.api_client_v1.configuration import Configuration
 from .. import ConfigManager, Logger
 from .base_api_client import BaseApiClient
 from ..exceptions.reporter import ReporterException

--- a/qase-python-commons/src/qase/commons/client/base_api_client.py
+++ b/qase-python-commons/src/qase/commons/client/base_api_client.py
@@ -1,7 +1,7 @@
 import abc
-from typing import Dict, Union
+from typing import Union
 
-from qaseio import Project, AttachmentGet
+from qase.api_client_v1 import Project, AttachmentGet
 
 from ..models import Attachment
 

--- a/qase-python-commons/src/qase/commons/loader.py
+++ b/qase-python-commons/src/qase/commons/loader.py
@@ -1,7 +1,7 @@
-from qaseio.api_client import ApiClient
-from qaseio.configuration import Configuration
-from qaseio.api.plans_api import PlansApi
-from qaseio.rest import ApiException
+from qase.api_client_v1.api_client import ApiClient
+from qase.api_client_v1.configuration import Configuration
+from qase.api_client_v1.api.plans_api import PlansApi
+from qase.api_client_v1.exceptions import ApiException
 
 import certifi
 


### PR DESCRIPTION
qase-python-commons: migrate to a new client
--
Migrate from `qaseio` client to `qase-api-client`.

---
release: qase-python-commons 3.0.2b2