### PR TITLE
release: qase-api-v2-client 1.0.0b2

### DIFF
--- a/qase-api-v2-client/README.md
+++ b/qase-api-v2-client/README.md
@@ -30,7 +30,7 @@ Then import the package:
 
 ```python
 
-import qase
+import qase.api_client_v2
 ```
 
 ### Setuptools
@@ -47,7 +47,7 @@ Then import the package:
 
 ```python
 
-import qase
+import qase.api_client_v2
 ```
 
 ### Tests
@@ -59,12 +59,12 @@ Execute `pytest` to run the tests.
 Please follow the [installation procedure](#installation--usage) and then run the following:
 
 ```python
-from qase.rest import ApiException
+from qase.api_client_v2.rest import ApiException
 from pprint import pprint
 
 # Defining the host is optional and defaults to https://api.qase.io/v2
 # See configuration.py for a list of all supported configuration parameters.
-configuration = qase.Configuration(
+configuration = qase.api_client_v2.Configuration(
     host="https://api.qase.io/v2"
 )
 
@@ -81,12 +81,12 @@ configuration.api_key['TokenAuth'] = os.environ["API_KEY"]
 
 
 # Enter a context with an instance of the API client
-with qase.ApiClient(configuration) as api_client:
+with qase.api_client_v2.ApiClient(configuration) as api_client:
     # Create an instance of the API class
-    api_instance = qase.ResultsApi(api_client)
+    api_instance = qase.api_client_v2.ResultsApi(api_client)
     project_code = 'project_code_example'  # str | 
     run_id = 56  # int | 
-    result_create = qase.ResultCreate()  # ResultCreate | 
+    result_create = qase.api_client_v2.ResultCreate()  # ResultCreate | 
 
     try:
         # (Beta) Create test run result

--- a/qase-api-v2-client/docs/BaseErrorFieldResponse.md
+++ b/qase-api-v2-client/docs/BaseErrorFieldResponse.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import BaseErrorFieldResponse
+from qase.api_clinet_v2.models import BaseErrorFieldResponse
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/BaseErrorFieldResponseErrorFieldsInner.md
+++ b/qase-api-v2-client/docs/BaseErrorFieldResponseErrorFieldsInner.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import BaseErrorFieldResponseErrorFieldsInner
+from src import BaseErrorFieldResponseErrorFieldsInner
 
 # TODO update the JSON string below
 json = "{}"
@@ -23,7 +23,8 @@ print(BaseErrorFieldResponseErrorFieldsInner.to_json())
 # convert the object into a dict
 base_error_field_response_error_fields_inner_dict = base_error_field_response_error_fields_inner_instance.to_dict()
 # create an instance of BaseErrorFieldResponseErrorFieldsInner from a dict
-base_error_field_response_error_fields_inner_form_dict = base_error_field_response_error_fields_inner.from_dict(base_error_field_response_error_fields_inner_dict)
+base_error_field_response_error_fields_inner_form_dict = base_error_field_response_error_fields_inner.from_dict(
+    base_error_field_response_error_fields_inner_dict)
 ```
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/qase-api-v2-client/docs/BaseErrorResponse.md
+++ b/qase-api-v2-client/docs/BaseErrorResponse.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import BaseErrorResponse
+from src import BaseErrorResponse
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/CreateResultV2422Response.md
+++ b/qase-api-v2-client/docs/CreateResultV2422Response.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import CreateResultV2422Response
+from src import CreateResultV2422Response
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/CreateResultsRequestV2.md
+++ b/qase-api-v2-client/docs/CreateResultsRequestV2.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import CreateResultsRequestV2
+from src import CreateResultsRequestV2
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/RelationSuite.md
+++ b/qase-api-v2-client/docs/RelationSuite.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import RelationSuite
+from src import RelationSuite
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/RelationSuiteItem.md
+++ b/qase-api-v2-client/docs/RelationSuiteItem.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import RelationSuiteItem
+from src import RelationSuiteItem
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultCreate.md
+++ b/qase-api-v2-client/docs/ResultCreate.md
@@ -24,7 +24,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultCreate
+from src import ResultCreate
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultExecution.md
+++ b/qase-api-v2-client/docs/ResultExecution.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultExecution
+from src import ResultExecution
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultRelations.md
+++ b/qase-api-v2-client/docs/ResultRelations.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultRelations
+from src import ResultRelations
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultStep.md
+++ b/qase-api-v2-client/docs/ResultStep.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultStep
+from src import ResultStep
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultStepData.md
+++ b/qase-api-v2-client/docs/ResultStepData.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultStepData
+from src import ResultStepData
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultStepExecution.md
+++ b/qase-api-v2-client/docs/ResultStepExecution.md
@@ -15,7 +15,7 @@ Name | Type | Description | Notes
 ## Example
 
 ```python
-from src.qase.models import ResultStepExecution
+from src import ResultStepExecution
 
 # TODO update the JSON string below
 json = "{}"

--- a/qase-api-v2-client/docs/ResultsApi.md
+++ b/qase-api-v2-client/docs/ResultsApi.md
@@ -21,14 +21,14 @@ This method allows to create single test run result.  If there is no free space 
 
 ```python
 import qase
-from src.qase.models import ResultCreate
-from src.qase.rest import ApiException
+from src import ResultCreate
+from src import ApiException
 from pprint import pprint
 
 # Defining the host is optional and defaults to https://api.qase.io/v2
 # See configuration.py for a list of all supported configuration parameters.
 configuration = qase.Configuration(
-    host = "https://api.qase.io/v2"
+    host="https://api.qase.io/v2"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -46,9 +46,9 @@ configuration.api_key['TokenAuth'] = os.environ["API_KEY"]
 with qase.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = qase.ResultsApi(api_client)
-    project_code = 'project_code_example' # str | 
-    run_id = 56 # int | 
-    result_create = qase.ResultCreate() # ResultCreate | 
+    project_code = 'project_code_example'  # str | 
+    run_id = 56  # int | 
+    result_create = qase.ResultCreate()  # ResultCreate | 
 
     try:
         # (Beta) Create test run result
@@ -107,14 +107,14 @@ This method allows to create several test run results at once.  If there is no f
 
 ```python
 import qase
-from src.qase.models import CreateResultsRequestV2
-from src.qase.rest import ApiException
+from src import CreateResultsRequestV2
+from src import ApiException
 from pprint import pprint
 
 # Defining the host is optional and defaults to https://api.qase.io/v2
 # See configuration.py for a list of all supported configuration parameters.
 configuration = qase.Configuration(
-    host = "https://api.qase.io/v2"
+    host="https://api.qase.io/v2"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -132,9 +132,9 @@ configuration.api_key['TokenAuth'] = os.environ["API_KEY"]
 with qase.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = qase.ResultsApi(api_client)
-    project_code = 'project_code_example' # str | 
-    run_id = 56 # int | 
-    create_results_request_v2 = qase.CreateResultsRequestV2() # CreateResultsRequestV2 | 
+    project_code = 'project_code_example'  # str | 
+    run_id = 56  # int | 
+    create_results_request_v2 = qase.CreateResultsRequestV2()  # CreateResultsRequestV2 | 
 
     try:
         # (Beta) Bulk create test run result

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "1.0.0b1"
+version = "1.0.0b2"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-v2-client/src/qase/api_client_v2/__init__.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/__init__.py
@@ -18,7 +18,7 @@
 __version__ = "1.0.0"
 
 # import apis into sdk package
-from .api.results_api import ResultsApi
+from qase.api_client_v2.api.results_api import ResultsApi
 
 # import ApiClient
 

--- a/qase-api-v2-client/src/qase/api_client_v2/api/__init__.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/api/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
 # import apis into api package
-from .results_api import ResultsApi
+from qase.api_client_v2.api.results_api import ResultsApi
 

--- a/qase-api-v2-client/src/qase/api_client_v2/api/results_api.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/api/results_api.py
@@ -17,12 +17,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import StrictInt, StrictStr
-from src.qase.api_client_v2.models.create_results_request_v2 import CreateResultsRequestV2
-from src.qase.api_client_v2.models.result_create import ResultCreate
+from qase.api_client_v2.models.create_results_request_v2 import CreateResultsRequestV2
+from qase.api_client_v2.models.result_create import ResultCreate
 
-from src.qase.api_client_v2.api_client import ApiClient, RequestSerialized
-from src.qase.api_client_v2.api_response import ApiResponse
-from src.qase.api_client_v2.rest import RESTResponseType
+from qase.api_client_v2.api_client import ApiClient, RequestSerialized
+from qase.api_client_v2.api_response import ApiResponse
+from qase.api_client_v2.rest import RESTResponseType
 
 
 class ResultsApi:

--- a/qase-api-v2-client/src/qase/api_client_v2/api_client.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/api_client.py
@@ -25,10 +25,10 @@ import tempfile
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict
 
-from .configuration import Configuration
-from .api_response import ApiResponse, T as ApiResponseT
-from . import rest
-from .exceptions import (
+from qase.api_client_v2.configuration import Configuration
+from qase.api_client_v2.api_response import ApiResponse, T as ApiResponseT
+from qase.api_client_v2 import rest
+from qase.api_client_v2.exceptions import (
     ApiValueError,
     ApiException
 )

--- a/qase-api-v2-client/src/qase/api_client_v2/models/base_error_field_response.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/base_error_field_response.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List
-from .base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
+from qase.api_client_v2.models.base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/create_result_v2422_response.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/create_result_v2422_response.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List
-from .base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
+from qase.api_client_v2.models.base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/create_results_request_v2.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/create_results_request_v2.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
-from .result_create import ResultCreate
+from qase.api_client_v2.models.result_create import ResultCreate
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/relation_suite.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/relation_suite.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
-from .relation_suite_item import RelationSuiteItem
+from qase.api_client_v2.models.relation_suite_item import RelationSuiteItem
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_create.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_create.py
@@ -20,10 +20,10 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Union
-from .result_execution import ResultExecution
-from .result_relations import ResultRelations
-from .result_step import ResultStep
-from .result_steps_type import ResultStepsType
+from qase.api_client_v2.models.result_execution import ResultExecution
+from qase.api_client_v2.models.result_relations import ResultRelations
+from qase.api_client_v2.models.result_step import ResultStep
+from qase.api_client_v2.models.result_steps_type import ResultStepsType
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_relations.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_relations.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
-from .relation_suite import RelationSuite
+from qase.api_client_v2.models.relation_suite import RelationSuite
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_step.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_step.py
@@ -20,8 +20,8 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List
-from .result_step_data import ResultStepData
-from .result_step_execution import ResultStepExecution
+from qase.api_client_v2.models.result_step_data import ResultStepData
+from qase.api_client_v2.models.result_step_execution import ResultStepExecution
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_step_execution.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_step_execution.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Union
-from .result_step_status import ResultStepStatus
+from qase.api_client_v2.models.result_step_status import ResultStepStatus
 from typing import Optional, Set
 from typing_extensions import Self
 

--- a/qase-api-v2-client/src/qase/api_client_v2/rest.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/rest.py
@@ -20,7 +20,7 @@ import ssl
 
 import urllib3
 
-from .exceptions import ApiException, ApiValueError
+from qase.api_client_v2.exceptions import ApiException, ApiValueError
 
 SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
 RESTResponseType = urllib3.HTTPResponse

--- a/qase-api-v2-client/test/test_base_error_field_response.py
+++ b/qase-api-v2-client/test/test_base_error_field_response.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.base_error_field_response import BaseErrorFieldResponse
+from qase.api_client_v2.models.base_error_field_response import BaseErrorFieldResponse
 
 class TestBaseErrorFieldResponse(unittest.TestCase):
     """BaseErrorFieldResponse unit test stubs"""

--- a/qase-api-v2-client/test/test_base_error_field_response_error_fields_inner.py
+++ b/qase-api-v2-client/test/test_base_error_field_response_error_fields_inner.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
+from qase.api_client_v2.models.base_error_field_response_error_fields_inner import BaseErrorFieldResponseErrorFieldsInner
 
 class TestBaseErrorFieldResponseErrorFieldsInner(unittest.TestCase):
     """BaseErrorFieldResponseErrorFieldsInner unit test stubs"""

--- a/qase-api-v2-client/test/test_base_error_response.py
+++ b/qase-api-v2-client/test/test_base_error_response.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.base_error_response import BaseErrorResponse
+from qase.api_client_v2.models.base_error_response import BaseErrorResponse
 
 class TestBaseErrorResponse(unittest.TestCase):
     """BaseErrorResponse unit test stubs"""

--- a/qase-api-v2-client/test/test_create_result_v2422_response.py
+++ b/qase-api-v2-client/test/test_create_result_v2422_response.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.create_result_v2422_response import CreateResultV2422Response
+from qase.api_client_v2.models.create_result_v2422_response import CreateResultV2422Response
 
 class TestCreateResultV2422Response(unittest.TestCase):
     """CreateResultV2422Response unit test stubs"""

--- a/qase-api-v2-client/test/test_create_results_request_v2.py
+++ b/qase-api-v2-client/test/test_create_results_request_v2.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.create_results_request_v2 import CreateResultsRequestV2
+from qase.api_client_v2.models.create_results_request_v2 import CreateResultsRequestV2
 
 class TestCreateResultsRequestV2(unittest.TestCase):
     """CreateResultsRequestV2 unit test stubs"""

--- a/qase-api-v2-client/test/test_relation_suite.py
+++ b/qase-api-v2-client/test/test_relation_suite.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.relation_suite import RelationSuite
+from qase.api_client_v2.models.relation_suite import RelationSuite
 
 class TestRelationSuite(unittest.TestCase):
     """RelationSuite unit test stubs"""

--- a/qase-api-v2-client/test/test_relation_suite_item.py
+++ b/qase-api-v2-client/test/test_relation_suite_item.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.relation_suite_item import RelationSuiteItem
+from qase.api_client_v2.models.relation_suite_item import RelationSuiteItem
 
 class TestRelationSuiteItem(unittest.TestCase):
     """RelationSuiteItem unit test stubs"""

--- a/qase-api-v2-client/test/test_result_create.py
+++ b/qase-api-v2-client/test/test_result_create.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_create import ResultCreate
+from qase.api_client_v2.models.result_create import ResultCreate
 
 class TestResultCreate(unittest.TestCase):
     """ResultCreate unit test stubs"""

--- a/qase-api-v2-client/test/test_result_execution.py
+++ b/qase-api-v2-client/test/test_result_execution.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_execution import ResultExecution
+from qase.api_client_v2.models.result_execution import ResultExecution
 
 class TestResultExecution(unittest.TestCase):
     """ResultExecution unit test stubs"""

--- a/qase-api-v2-client/test/test_result_relations.py
+++ b/qase-api-v2-client/test/test_result_relations.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_relations import ResultRelations
+from qase.api_client_v2.models.result_relations import ResultRelations
 
 class TestResultRelations(unittest.TestCase):
     """ResultRelations unit test stubs"""

--- a/qase-api-v2-client/test/test_result_step.py
+++ b/qase-api-v2-client/test/test_result_step.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_step import ResultStep
+from qase.api_client_v2.models.result_step import ResultStep
 
 class TestResultStep(unittest.TestCase):
     """ResultStep unit test stubs"""

--- a/qase-api-v2-client/test/test_result_step_data.py
+++ b/qase-api-v2-client/test/test_result_step_data.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_step_data import ResultStepData
+from qase.api_client_v2.models.result_step_data import ResultStepData
 
 class TestResultStepData(unittest.TestCase):
     """ResultStepData unit test stubs"""

--- a/qase-api-v2-client/test/test_result_step_execution.py
+++ b/qase-api-v2-client/test/test_result_step_execution.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.models.result_step_execution import ResultStepExecution
+from qase.api_client_v2.models.result_step_execution import ResultStepExecution
 
 class TestResultStepExecution(unittest.TestCase):
     """ResultStepExecution unit test stubs"""

--- a/qase-api-v2-client/test/test_results_api.py
+++ b/qase-api-v2-client/test/test_results_api.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from src.qase.api_client_v2.api import ResultsApi
+from qase.api_client_v2.api import ResultsApi
 
 
 class TestResultsApi(unittest.TestCase):

--- a/qase-api-v2-client/tox.ini
+++ b/qase-api-v2-client/tox.ini
@@ -6,4 +6,4 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
 
 commands=
-   pytest --cov=src.qase.api_client_v2
+   pytest --cov=qase.api_client_v2


### PR DESCRIPTION
qase-api-v2-client: update imports inside the package
--
Update the imports from `src.qase.api_client_v2` to `qase.api_client_v2`.

---
release: qase-api-v2-client 1.0.0b2