### PR TITLE
qase-pytest: fix sleep profiler

### DIFF
--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.0.0b1"
+version = "6.0.0b2"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -100,8 +100,8 @@ class QasePytestPlugin:
             self.reporter.enable_profilers()
             self.start_pytest_item(item)
             yield
-            self.reporter.disable_profilers()
             self.finish_pytest_item(item)
+            self.reporter.disable_profilers()
         else:
             yield
 

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b3"
+version = "3.0.2b4"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/profilers/sleep.py
+++ b/qase-python-commons/src/qase/commons/profilers/sleep.py
@@ -30,7 +30,7 @@ class SleepProfiler:
         def wrapper(duration, *args, **kwargs):
             self._log_pre_sleep(duration)
             func(duration, *args, **kwargs)
-            self._log_post_sleep(duration)
+            self._log_post_sleep()
 
         return wrapper
 
@@ -44,7 +44,7 @@ class SleepProfiler:
         # Assuming runtime can start a step without a request/response
         self.runtime.add_step(self.step)
 
-    def _log_post_sleep(self, duration):
+    def _log_post_sleep(self):
         # Log or track the post-sleep call
         # Update the step status to passed as sleep doesn't fail like network calls
         self.runtime.finish_step(


### PR DESCRIPTION
qase-pytest: fix sleep profiler
--
The sleep profiler was turned off until the test data collection was completed. Now the profilers will turn off after the test is completed.

---

release: qase-python-commons 3.0.2b4, qase-pytest 6.0.0b2