### PR TITLE
release: qase-python-commons 3.0.2b5

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b4"
+version = "3.0.2b5"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/reporters/core.py
+++ b/qase-python-commons/src/qase/commons/reporters/core.py
@@ -109,7 +109,8 @@ class QaseCoreReporter:
             if profiler == "network":
                 # Lazy import
                 from ..profilers import NetworkProfilerSingleton
-                NetworkProfilerSingleton.init(runtime=runtime)
+                NetworkProfilerSingleton.init(runtime=runtime,
+                                              skip_domain=self.config.get("testops.api.host", "qase.io"))
                 self.profilers.append(NetworkProfilerSingleton.get_instance())
             if profiler == "sleep":
                 from ..profilers import SleepProfiler


### PR DESCRIPTION
Fixed the following issues with network profiler:
- ignore requests to `qase.io` host
- check that `body` and `headers` attributes are in the request
- fix ignoring response for `urllib3` package
- add a creation step for redirected requests