### PR TITLE
release: qase-python-commons 3.0.2b6

### DIFF
--- a/qase-python-commons/src/qase/commons/utils.py
+++ b/qase-python-commons/src/qase/commons/utils.py
@@ -6,8 +6,6 @@ import pip
 import string
 import uuid
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 
 class QaseUtils:
 
@@ -61,14 +59,6 @@ class QaseUtils:
     @staticmethod
     def get_filename(path) -> str:
         return os.path.basename(path)
-
-    @staticmethod
-    def package_version(name):
-        try:
-            version = get_distribution(name).version
-        except DistributionNotFound:
-            version = "unknown"
-        return version
 
 
 class StringFormatter(string.Formatter):


### PR DESCRIPTION
Fixed the issue:
`[ ERROR ] Taking listener 'qaseio.robotframework.Listener' into use failed: Importing listener 'qaseio.robotframework.Listener' failed: ModuleNotFoundError: No module named 'pkg_resources'`