### PR TITLE
release: qase-python-commons 3.0.2b7 and qase-robotframework 3.0.0b2

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b6"
+version = "3.0.2b7"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/logger.py
+++ b/qase-python-commons/src/qase/commons/logger.py
@@ -4,7 +4,7 @@ import os
 
 
 class Logger:
-    def __init__(self, debug: bool = False, prefix: str = '', dir: str = './logs') -> None:
+    def __init__(self, debug: bool = False, prefix: str = '', dir: str = os.path.join('.', 'logs')) -> None:
         self.debug = debug
         if self.debug:
             filename = f'{prefix}_{self._get_timestamp()}.log'

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.0.0b1"
+version = "3.0.0b2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qaseio/robotframework/listener.py
+++ b/qase-robotframework/src/qaseio/robotframework/listener.py
@@ -90,7 +90,8 @@ class Listener:
         self.step_uuid = id
 
     def end_keyword(self, name, attributes):
-        self.runtime.finish_step(self.step_uuid, STATUSES[attributes["status"]])
+        status = attributes["status"] if attributes["status"] != 'skipped' else 'blocked'
+        self.runtime.finish_step(self.step_uuid, STATUSES[status])
         self.step_uuid = self.runtime.steps[self.step_uuid].parent_id
 
     def end_suite(self, name, attributes: EndSuiteModel):


### PR DESCRIPTION
release: qase-python-commons 3.0.2b7
--
Fixed the issue:
Creating instance failed: OSError: [ Errno 22 ] Invalid argument: './logs\\file.log'

---

release: qase-robotframework 3.0.0b2
--
Fixed an issue with unsupported step status. If the step is `skipped` then mark the step as `blocked`.