### PR TITLE
release: qase-robotframework 3.0.0b2 and qase-python-commons 3.0.2b8

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b7"
+version = "3.0.2b8"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -30,7 +30,7 @@ class ConfigManager:
     def get(self, key, default=None, value_type=None):
         # Use _get_config method to get the value. If None, return default.
         value = self._get_config(key)
-        if value_type and value_type == bool:
+        if value and value_type and value_type == bool:
             return self.parseBool(value)
         return value or default
 

--- a/qase-python-commons/src/qase/commons/models/__init__.py
+++ b/qase-python-commons/src/qase/commons/models/__init__.py
@@ -1,4 +1,4 @@
-from .result import Result
+from .result import Result, Field
 from .run import Run
 from .attachment import Attachment
 from .suite import Suite
@@ -13,5 +13,6 @@ __all__ = [
     Suite,
     Relation,
     Step,
-    Runtime
+    Runtime,
+    Field
 ]

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.0.0b1"
+version = "3.0.0b2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qaseio/robotframework/listener.py
+++ b/qase-robotframework/src/qaseio/robotframework/listener.py
@@ -3,7 +3,7 @@ import re
 import uuid
 
 from qase.commons import ConfigManager
-from qase.commons.models import Result, Suite, Step
+from qase.commons.models import Result, Suite, Step, Field
 from qase.commons.models.step import StepType, StepGherkinData
 from qase.commons.reporters import QaseCoreReporter
 from qase.commons.models.runtime import Runtime
@@ -47,7 +47,7 @@ class Listener:
         logger.debug("Starting test '%s'", name)
 
         self.runtime.result = Result(title=name, signature=name)
-
+        self.runtime.steps = {}
         case_id = self._extract_ids(attributes.get("tags"))
 
         if case_id:
@@ -61,12 +61,10 @@ class Listener:
         self.runtime.result.execution.stacktrace = attributes.get("message")
         self.runtime.result.add_steps([step for key, step in self.runtime.steps.items()])
 
-        if self.runtime.result.testops_id is None:
-            self.runtime.result.case.title = name
-            self.runtime.result.case.description = attributes.get("doc")
+        self.runtime.result.add_field(Field("description", attributes.get("doc")))
 
-            if self.suite:
-                self.runtime.result.suite = Suite(self.suite.get("title"), self.suite.get("description"))
+        if self.suite:
+            self.runtime.result.suite = Suite(self.suite.get("title"), self.suite.get("description"))
 
         self.reporter.add_result(self.runtime.result)
 


### PR DESCRIPTION
release: qase-python-commons 3.0.2b8
--
Fixed the issues:
- return a correct value from the config if the value didn't find
- mark `Field` model as exported
- fix the problem when the test run  would be completed before the results were sent

---

release: qase-robotframework 3.0.0b2
--
Fixed the issue:
AttributeError: 'Result' object has no attribute 'case'