### PR TITLE
release: qase-robotframework 3.0.0b4

### DIFF
--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.0.0b3"
+version = "3.0.0b4"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -48,13 +48,13 @@ class Listener:
 
         self.runtime.result = Result(title=name, signature=name)
         self.runtime.steps = {}
-        case_id = self._extract_ids(attributes.get("tags"))
-
-        if case_id:
-            self.runtime.result.testops_id = int(case_id)
 
     def end_test(self, name, attributes: EndTestModel):
         logger.debug("Finishing test '%s'", name)
+
+        case_id = self._extract_ids(attributes.get("tags"))
+        if case_id:
+            self.runtime.result.testops_id = int(case_id)
 
         self.runtime.result.execution.complete()
         self.runtime.result.execution.set_status(STATUSES[attributes.get("status")])


### PR DESCRIPTION
release: qase-robotframework 3.0.0b4
--
The logic for extracting Qase ID has been changed. The reporter will extract the Qase ID after ending test.