### PR TITLE
release: qase-python-commons 3.0.2b9

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b8"
+version = "3.0.2b9"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/logger.py
+++ b/qase-python-commons/src/qase/commons/logger.py
@@ -27,6 +27,6 @@ class Logger:
             self.log(message, 'debug')
 
     @staticmethod
-    def _get_timestamp(format: str = "%Y%m%d_%H:%M:%S"):
+    def _get_timestamp(format: str = "%Y%m%d_%H_%M_%S"):
         now = datetime.datetime.now()
         return now.strftime(format)


### PR DESCRIPTION
release: qase-python-commons 3.0.2b9
--
Fixed the issues on Windows OS:
[Errno 22] Invalid argument: `.\\logs\\_20240101_00:00:00`