### PR TITLE
release: qase-python-commons 3.0.2

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2b9"
+version = "3.0.2"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -30,8 +30,8 @@ requires-python = ">=3.7"
 dependencies = [
     "certifi>=2024.2.2",
     "attrs>=23.2.0",
-    "qase-api-client~=1.0.0b2",
-    "qase-api-v2-client~=1.0.0b2",
+    "qase-api-client~=1.0.0",
+    "qase-api-v2-client~=1.0.0",
     "more_itertools"
 ]
 


### PR DESCRIPTION
release: qase-python-commons 3.0.2
--
Updated client packages