### PR TITLE
release: qase-api-client 1.0.1

### DIFF
--- a/qase-api-client/src/qase/api_client_v1/__init__.py
+++ b/qase-api-client/src/qase/api_client_v1/__init__.py
@@ -62,7 +62,7 @@ from qase.api_client_v1.models.author_response import AuthorResponse
 from qase.api_client_v1.models.base_response import BaseResponse
 from qase.api_client_v1.models.bulk200_response import Bulk200Response
 from qase.api_client_v1.models.bulk200_response_all_of_result import Bulk200ResponseAllOfResult
-from qase.api_client_v1.models.configuration import Configuration
+from qase.api_client_v1.models.configuration import ConfigurationModel
 from qase.api_client_v1.models.configuration_create import ConfigurationCreate
 from qase.api_client_v1.models.configuration_group import ConfigurationGroup
 from qase.api_client_v1.models.configuration_group_create import ConfigurationGroupCreate

--- a/qase-api-client/src/qase/api_client_v1/models/__init__.py
+++ b/qase-api-client/src/qase/api_client_v1/models/__init__.py
@@ -30,7 +30,7 @@ from qase.api_client_v1.models.author_response import AuthorResponse
 from qase.api_client_v1.models.base_response import BaseResponse
 from qase.api_client_v1.models.bulk200_response import Bulk200Response
 from qase.api_client_v1.models.bulk200_response_all_of_result import Bulk200ResponseAllOfResult
-from qase.api_client_v1.models.configuration import Configuration
+from qase.api_client_v1.models.configuration import ConfigurationModel
 from qase.api_client_v1.models.configuration_create import ConfigurationCreate
 from qase.api_client_v1.models.configuration_group import ConfigurationGroup
 from qase.api_client_v1.models.configuration_group_create import ConfigurationGroupCreate

--- a/qase-api-client/src/qase/api_client_v1/models/configuration.py
+++ b/qase-api-client/src/qase/api_client_v1/models/configuration.py
@@ -23,7 +23,7 @@ from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
-class Configuration(BaseModel):
+class ConfigurationModel(BaseModel):
     """
     Configuration
     """ # noqa: E501

--- a/qase-api-client/src/qase/api_client_v1/models/configuration_group.py
+++ b/qase-api-client/src/qase/api_client_v1/models/configuration_group.py
@@ -20,7 +20,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
-from qase.api_client_v1.models.configuration import Configuration
+from qase.api_client_v1.models.configuration import ConfigurationModel
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -30,7 +30,7 @@ class ConfigurationGroup(BaseModel):
     """ # noqa: E501
     id: Optional[StrictInt] = None
     title: Optional[StrictStr] = None
-    configurations: Optional[List[Configuration]] = None
+    configurations: Optional[List[ConfigurationModel]] = None
     __properties: ClassVar[List[str]] = ["id", "title", "configurations"]
 
     model_config = ConfigDict(
@@ -93,7 +93,7 @@ class ConfigurationGroup(BaseModel):
         _obj = cls.model_validate({
             "id": obj.get("id"),
             "title": obj.get("title"),
-            "configurations": [Configuration.from_dict(_item) for _item in obj["configurations"]] if obj.get("configurations") is not None else None
+            "configurations": [ConfigurationModel.from_dict(_item) for _item in obj["configurations"]] if obj.get("configurations") is not None else None
         })
         return _obj
 

--- a/qase-api-client/test/test_configuration.py
+++ b/qase-api-client/test/test_configuration.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from qase.api_client_v1.models.configuration import Configuration
+from qase.api_client_v1.models.configuration import ConfigurationModel
 
 class TestConfiguration(unittest.TestCase):
     """Configuration unit test stubs"""
@@ -26,7 +26,7 @@ class TestConfiguration(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def make_instance(self, include_optional) -> Configuration:
+    def make_instance(self, include_optional) -> ConfigurationModel:
         """Test Configuration
             include_option is a boolean, when False only required
             params are included, when True both required and


### PR DESCRIPTION
Fix #212

Rename `Configuration` model to resolve duplicate name issues.