### PR TITLE
release: qase-pytest 6.0.1 and qase-python-commons 3.0.3

### DIFF
--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.0.0"
+version = "6.0.1"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -95,7 +95,7 @@ class QasePytestOptions:
             parser,
             group,
             "--qase-testops-run-complete",
-            dest="qase_testops_run_description",
+            dest="qase_testops_run_complete",
             type="bool",
             help="Complete run after tests execution"
         )

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.2"
+version = "3.0.3"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -30,7 +30,7 @@ class ConfigManager:
     def get(self, key, default=None, value_type=None):
         # Use _get_config method to get the value. If None, return default.
         value = self._get_config(key)
-        if value and value_type and value_type == bool:
+        if value is not None and value_type is not None and value_type == bool:
             return self.parseBool(value)
         return value or default
 


### PR DESCRIPTION
release: qase-python-commons 3.0.3
--
Fix an issue with getting bool parameter from the config then the parameter's value is False

---

release: qase-pytest 6.0.1
--
Change a name of the complete test run parameter for CLI arguments

Fix #160