### PR TITLE
release: qase-robotframework 3.1.0b2 and qase-python-commons 3.1.0b2

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.0b1"
+version = "3.1.0b2"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/reporters/core.py
+++ b/qase-python-commons/src/qase/commons/reporters/core.py
@@ -38,13 +38,13 @@ class QaseCoreReporter:
         if mode == Mode.testops:
             try:
                 self._load_testops_plan()
-                self.reporter = QaseTestOps(config=config, logger=self.logger)
+                self.reporter = QaseTestOps(config=self.config, logger=self.logger)
             except Exception as e:
                 self.logger.log('Failed to initialize TestOps reporter. Using fallback.', 'info')
                 self.logger.log(e, 'error')
                 self.reporter = self.fallback
         elif mode == Mode.report:
-            self.reporter = QaseReport(config=config, logger=self.logger)
+            self.reporter = QaseReport(config=self.config, logger=self.logger)
         else:
             self.reporter = None
 

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -4,20 +4,21 @@ import shutil
 import json
 import re
 from ..models import Result, Run, Attachment
-from .. import QaseUtils, ConfigManager, Logger
+from .. import QaseUtils, Logger
 from ..models.config.connection import Format
+from ..models.config.qaseconfig import QaseConfig
 
 
 class QaseReport:
     def __init__(
             self,
-            config: ConfigManager,
+            config: QaseConfig,
             logger: Logger
     ):
         self.duration = 0
         self.results = []
         self.attachments = []
-        self.config = config.config
+        self.config = config
         self.logger = logger
 
         self.report_path = self.config.report.connection.path

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -119,7 +119,7 @@ class QaseReport:
 
     # Saves a model to a file
     def _store_object(self, object, path, filename):
-        data = object.to_json()
+        data = object.__str__()
         if self.format == Format.jsonp:
             data = f"qaseJsonp({data});"
         with open(f"{path}/{filename}.{self.format.value}", 'w', encoding='utf-8') as f:

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -2,10 +2,11 @@ import threading
 
 from datetime import datetime
 from typing import List
-from .. import ConfigManager, Logger, ReporterException
+from .. import Logger, ReporterException
 from ..client.api_v1_client import ApiV1Client
 from ..client.base_api_client import BaseApiClient
 from ..models import Result
+from ..models.config.qaseconfig import QaseConfig
 
 DEFAULT_BATCH_SIZE = 200
 DEFAULT_THREAD_COUNT = 4
@@ -13,8 +14,8 @@ DEFAULT_THREAD_COUNT = 4
 
 class QaseTestOps:
 
-    def __init__(self, config: ConfigManager, logger: Logger) -> None:
-        self.config = config.config
+    def __init__(self, config: QaseConfig, logger: Logger) -> None:
+        self.config = config
         self.logger = logger
 
         self.client = self._prepare_client()

--- a/qase-python-commons/tests/tests_qase_commons/test_report.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_report.py
@@ -12,7 +12,7 @@ def test_QaseReport_init():
     config.config.report.connection.format = Format.json
     config.config.environment = "env1"
 
-    report = QaseReport(config, logger)
+    report = QaseReport(config.config, logger)
     assert report.report_path == "custom_path"
     assert report.format == Format.json
     assert report.environment == "env1"
@@ -24,7 +24,7 @@ def test_QaseReport_init():
 def test_QaseReport_start_run(mock_exists, mock_rmtree, mock_makedirs):
     logger = Logger()
     config = ConfigManager()
-    report = QaseReport(config, logger)
+    report = QaseReport(config.config, logger)
     report.start_run()
     assert mock_exists.called
     assert mock_rmtree.called
@@ -38,7 +38,7 @@ def test_QaseReport_start_run(mock_exists, mock_rmtree, mock_makedirs):
 def test_QaseReport_check_report_path(mock_makedirs, mock_rmtree, mock_exists):
     logger = Logger()
     config = ConfigManager()
-    report = QaseReport(config, logger)
+    report = QaseReport(config.config, logger)
     report._check_report_path()
     assert mock_exists.called
     assert mock_rmtree.called
@@ -51,7 +51,7 @@ def test_QaseReport_check_report_path(mock_makedirs, mock_rmtree, mock_exists):
 def test_QaseReport_recreate_dir(mock_makedirs, mock_rmtree, mock_exists):
     logger = Logger()
     config = ConfigManager()
-    report = QaseReport(config, logger)
+    report = QaseReport(config.config, logger)
     report._recreate_dir("some_path")
     assert mock_exists.called
     assert mock_rmtree.called
@@ -62,7 +62,7 @@ def test_QaseReport_recreate_dir(mock_makedirs, mock_rmtree, mock_exists):
 def test_QaseReport_store_object(mock_open):
     logger = Logger()
     config = ConfigManager()
-    report = QaseReport(config, logger)
+    report = QaseReport(config.config, logger)
     mock_object = MagicMock()
     mock_object.to_json.return_value = '{"key": "value"}'
     report._store_object(mock_object, "/path", "filename")

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.1.0b1"
+version = "3.1.0b2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -18,13 +18,13 @@ class Listener:
     ROBOT_LISTENER_API_VERSION = 2
 
     def __init__(self):
-        config = ConfigManager().config
+        config = ConfigManager()
         self.reporter = QaseCoreReporter(config)
         self.runtime = Runtime()
         self.step_uuid = None
         self.suite = {}
 
-        if config.debug:
+        if config.config.debug:
             logger.setLevel(logging.DEBUG)
             ch = logging.StreamHandler()
             formatter = logging.Formatter(


### PR DESCRIPTION
release: qase-robotframework 3.1.0b2
--
Fix an error:
`AttributeError: 'QaseConfig' object has no attribute 'validate_config'`

---

fix: problem with saving local report
--
Fix an error:
`'Run' object has no attribute 'to_json'`

---

refactor: change type of parameters
--
Change type of parameters for the constructor of reporters.