### PR TITLE
fix: configuration parser should allow uppercase

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.0b2"
+version = "3.1.0b3"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -10,7 +10,6 @@ class ConfigManager:
         self.logger = Logger()
         self.__config_file = config_file
         self.config = QaseConfig()
-        self.parse_bool = lambda d: d in ("y", "yes", "true", "1", 1, True)
 
         self.__load_file_config()
         self.__load_env_config()
@@ -56,7 +55,7 @@ class ConfigManager:
 
                     if config.get("debug"):
                         self.config.set_debug(
-                            self.parse_bool(config.get("debug"))
+                            config.get("debug")
                         )
 
                     if config.get("executionPlan"):
@@ -81,12 +80,12 @@ class ConfigManager:
 
                         if testops.get("defect"):
                             self.config.testops.set_defect(
-                                self.parse_bool(testops.get("defect"))
+                                testops.get("defect")
                             )
 
                         if testops.get("useV2"):
                             self.config.testops.set_use_v2(
-                                self.parse_bool(testops.get("useV2"))
+                                testops.get("useV2")
                             )
 
                         if testops.get("plan"):
@@ -109,7 +108,7 @@ class ConfigManager:
 
                             if run.get("complete"):
                                 self.config.testops.run.set_complete(
-                                    self.parse_bool(run.get("complete"))
+                                    run.get("complete")
                                 )
 
                         if testops.get("batch"):
@@ -143,7 +142,7 @@ class ConfigManager:
 
                             if pytest.get("captureLogs"):
                                 self.config.framework.pytest.set_capture_logs(
-                                    self.parse_bool(pytest.get("captureLogs"))
+                                    pytest.get("captureLogs")
                                 )
 
         except Exception as e:
@@ -168,7 +167,7 @@ class ConfigManager:
                     self.config.set_profilers(value.split(','))
 
                 if key == 'QASE_DEBUG':
-                    self.config.set_debug(self.parse_bool(value))
+                    self.config.set_debug(value)
 
                 if key == 'QASE_EXECUTION_PLAN_PATH':
                     self.config.execution_plan.set_path(value)
@@ -183,7 +182,7 @@ class ConfigManager:
                     self.config.testops.set_project(value)
 
                 if key == 'QASE_TESTOPS_DEFECT':
-                    self.config.testops.set_defect(self.parse_bool(value))
+                    self.config.testops.set_defect(value)
 
                 if key == 'QASE_TESTOPS_PLAN_ID':
                     self.config.testops.plan.set_id(value)
@@ -198,7 +197,7 @@ class ConfigManager:
                     self.config.testops.run.set_description(value)
 
                 if key == 'QASE_TESTOPS_RUN_COMPLETE':
-                    self.config.testops.run.set_complete(self.parse_bool(value))
+                    self.config.testops.run.set_complete(value)
 
                 if key == 'QASE_TESTOPS_BATCH_SIZE':
                     self.config.testops.batch.set_size(value)
@@ -213,7 +212,7 @@ class ConfigManager:
                     self.config.report.connection.set_format(value)
 
                 if key == 'QASE_PYTEST_CAPTURE_LOGS':
-                    self.config.framework.pytest.set_capture_logs(self.parse_bool(value))
+                    self.config.framework.pytest.set_capture_logs(value)
 
         except Exception as e:
             self.logger.log("Failed to load config from env vars {e}", "error")

--- a/qase-python-commons/src/qase/commons/models/config/framework.py
+++ b/qase-python-commons/src/qase/commons/models/config/framework.py
@@ -1,4 +1,5 @@
 from ..basemodel import BaseModel
+from ... import QaseUtils
 
 
 class PytestConfig(BaseModel):
@@ -7,8 +8,8 @@ class PytestConfig(BaseModel):
     def __init__(self):
         self.capture_logs = False
 
-    def set_capture_logs(self, capture_logs: bool):
-        self.capture_logs = capture_logs
+    def set_capture_logs(self, capture_logs):
+        self.capture_logs = QaseUtils.parse_bool(capture_logs)
 
 
 class Framework(BaseModel):

--- a/qase-python-commons/src/qase/commons/models/config/qaseconfig.py
+++ b/qase-python-commons/src/qase/commons/models/config/qaseconfig.py
@@ -4,6 +4,7 @@ from .framework import Framework
 from .report import ReportConfig
 from .testops import TestopsConfig
 from ..basemodel import BaseModel
+from ... import QaseUtils
 
 
 class Mode(Enum):
@@ -61,5 +62,5 @@ class QaseConfig(BaseModel):
     def set_root_suite(self, root_suite: str):
         self.root_suite = root_suite
 
-    def set_debug(self, debug: bool):
-        self.debug = debug
+    def set_debug(self, debug):
+        self.debug = QaseUtils.parse_bool(debug)

--- a/qase-python-commons/src/qase/commons/models/config/run.py
+++ b/qase-python-commons/src/qase/commons/models/config/run.py
@@ -1,4 +1,5 @@
 from ..basemodel import BaseModel
+from ... import QaseUtils
 
 
 class RunConfig(BaseModel):
@@ -16,8 +17,8 @@ class RunConfig(BaseModel):
     def set_description(self, description: str):
         self.description = description
 
-    def set_complete(self, complete: bool):
-        self.complete = complete
+    def set_complete(self, complete):
+        self.complete = QaseUtils.parse_bool(complete)
 
     def set_id(self, id: int):
         self.id = id

--- a/qase-python-commons/src/qase/commons/models/config/testops.py
+++ b/qase-python-commons/src/qase/commons/models/config/testops.py
@@ -3,6 +3,7 @@ from .batch import BatchConfig
 from .plan import PlanConfig
 from .run import RunConfig
 from ..basemodel import BaseModel
+from ... import QaseUtils
 
 
 class TestopsConfig(BaseModel):
@@ -24,8 +25,8 @@ class TestopsConfig(BaseModel):
     def set_project(self, project: str):
         self.project = project
 
-    def set_defect(self, defect: bool):
-        self.defect = defect
+    def set_defect(self, defect):
+        self.defect = QaseUtils.parse_bool(defect)
 
-    def set_use_v2(self, use_v2: bool):
-        self.use_v2 = use_v2
+    def set_use_v2(self, use_v2):
+        self.use_v2 = QaseUtils.parse_bool(use_v2)

--- a/qase-python-commons/src/qase/commons/utils.py
+++ b/qase-python-commons/src/qase/commons/utils.py
@@ -38,6 +38,10 @@ class QaseUtils:
         return f"{os.getpid()}-{threading.current_thread().name}"
 
     @staticmethod
+    def parse_bool(value) -> bool:
+        return value in ("y", "yes", "true", "True", "TRUE", "1", 1, True)
+
+    @staticmethod
     def uuid() -> str:
         return str(uuid.uuid4())
 


### PR DESCRIPTION
fix: configuration parser should allow uppercase
--
Fix the problem with bool parameters. The config manager didn't get values in uppercase.

[#176]