### PR TITLE
feature: add a signature to the test results

### DIFF
--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -149,7 +149,7 @@ class QasePytestPlugin:
     def start_pytest_item(self, item):
         self.runtime.result = Result(
             title=self._get_title(item),
-            signature=self._get_signature(item),
+            signature='',
         )
         self._set_fields(item)
         self._set_tags(item)
@@ -159,6 +159,7 @@ class QasePytestPlugin:
         self._set_params(item)
         self._set_suite(item)
         self._set_relations(item)
+        self._get_signature(item)
 
     def finish_pytest_item(self, item):
         self.runtime.result.execution.complete()
@@ -212,8 +213,12 @@ class QasePytestPlugin:
 
         return str(title)
 
-    def _get_signature(self, item) -> str:
-        return re.sub(r'\[.*?\]', '', item.nodeid)
+    def _get_signature(self, item):
+        self.runtime.result.signature = item.nodeid.replace("/", "::")
+        if self.runtime.result.testops_id:
+            self.runtime.result.signature += f"::{self.runtime.result.testops_id}"
+        for key, val in self.runtime.result.params.items():
+            self.runtime.result.signature += f"::{{{key}:{val}}}"
 
     def _set_relations(self, item) -> None:
         # TODO: Add support for relations

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import uuid
 
@@ -40,6 +41,7 @@ class Listener:
             "title": name,
             "description": attributes["doc"]
         }
+
         logger.debug("Starting suite '%s'", name)
 
     def start_test(self, name, attributes: StartTestModel):
@@ -64,6 +66,17 @@ class Listener:
 
         if self.suite:
             self.runtime.result.suite = Suite(self.suite.get("title"), self.suite.get("description"))
+
+        if "source" in attributes:
+            file_path = attributes["source"].split(os.getcwd() + '/')[1]
+            signature = '::'.join(file_path.split("/"))
+            if self.suite:
+                signature += f"::{self.suite.get('title').lower().replace(' ', '_')}::{name.lower().replace(' ', '_')}"
+
+            if self.runtime.result.testops_id:
+                signature += f"::{self.runtime.result.testops_id}"
+
+            self.runtime.result.signature = signature
 
         self.reporter.add_result(self.runtime.result)
 

--- a/qase-robotframework/src/qase/robotframework/models.py
+++ b/qase-robotframework/src/qase/robotframework/models.py
@@ -59,6 +59,7 @@ class EndTestModel(TypedDict):
     elapsedtime: int
     status: str
     message: str
+    source: str
 
 
 class StartKeywordModel(TypedDict):


### PR DESCRIPTION
feature: add a signature to the test results
--
Implement a method which constructs the signature to each test result.
It takes the file path, the suites, the qase ids and the parameters.