### PR TITLE
fix: issues with parameters in qase-pytest

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,17 @@
+# qase-pytest 6.1.0b2
+
+## What's new
+
+Fixed the following issues:
+
+- issue with `qase-pytest-capture-logs` parameter [#234].
+   When using the "qase-pytest-capture-logs" parameter, an error occurred:
+   `pytest: error: unrecognized arguments: --qase-pytest-capture-logs=true`
+    
+- issue with `qase-testops-batch-size` parameter [#235]. 
+  When using the "qase-testops-batch-size" parameter, an error occurred:
+  `TypeError: '>' not supported between instances of 'str' and 'int'`
+
 # qase-pytest 6.1.0b1
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.0b1"
+version = "6.1.0b2"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -106,7 +106,7 @@ def setup_config_manager(config):
                 config_manager.config.report.connection.set_format(config.option.__dict__[option])
 
             if option == "qase_testops_batch_size" and config.option.__dict__[option] is not None:
-                config_manager.config.testops.batch.set_size(config.option.__dict__[option])
+                config_manager.config.testops.batch.set_size(int(config.option.__dict__[option]))
 
             if option == "qase_pytest_capture_logs" and config.option.__dict__[option] is not None:
                 config_manager.config.pytest.set_capture_logs(config.option.__dict__[option])

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -108,6 +108,9 @@ def setup_config_manager(config):
             if option == "qase_testops_batch_size" and config.option.__dict__[option] is not None:
                 config_manager.config.testops.batch.set_size(config.option.__dict__[option])
 
+            if option == "qase_pytest_capture_logs" and config.option.__dict__[option] is not None:
+                config_manager.config.pytest.set_capture_logs(config.option.__dict__[option])
+
     return config_manager
 
 

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -165,6 +165,15 @@ class QasePytestOptions:
             help="Profilers to use for tests. Available: `network`, `db`, `sleep`"
         )
 
+        QasePytestOptions.add_option(
+            parser,
+            group,
+            "--qase-pytest-capture-logs",
+            dest="qase-pytest-capture-logs",
+            type="bool",
+            help="Capture logs from pytest"
+        )
+
     @staticmethod
     def add_option(parser, group, option, dest, default=None, type=None, **kwargs):
         # We are going to add options that were not added before through the manager

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -113,6 +113,7 @@ class QasePytestOptions:
             group,
             "--qase-testops-batch-size",
             dest="qase_testops_batch_size",
+            type="int",
             help="Define batch size of results. Default: 200."
         )
 

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -274,6 +274,7 @@ class QasePytestPlugin:
         marker = item.get_closest_marker("qase_suite")
         if marker:
             self.runtime.result.suite = Suite(marker.kwargs.get("title"), marker.kwargs.get("description"))
+            return
         self._get_suite(item)
 
     def _get_suite(self, item):


### PR DESCRIPTION
fix: an issue with `qase-pytest-capture-logs` parameter
--
When using the "qase-pytest-capture-logs" parameter, an error occurred:
`pytest: error: unrecognized arguments: --qase-pytest-capture-logs=true`

Fix #234

---

fix: an issue with `qase-testops-batch-size` parameter
--
When using the "qase-testops-batch-size" parameter, an error occurred:
`TypeError: '>' not supported between instances of 'str' and 'int'`

Fix #235