### PR TITLE
fix: an issue with `qase-pytest-capture-logs` parameter

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 6.1.0b3
+
+## What's new
+
+Fixed an issue then `qase-pytest-capture-logs` parameter did not set correct value.
+
 # qase-pytest 6.1.0b2
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.0b2"
+version = "6.1.0b3"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -79,10 +79,10 @@ def setup_config_manager(config):
                 config_manager.config.testops.api.set_host(config.option.__dict__[option])
 
             if option == "qase_testops_plan_id" and config.option.__dict__[option] is not None:
-                config_manager.config.testops.plan.set_id(config.option.__dict__[option])
+                config_manager.config.testops.plan.set_id(int(config.option.__dict__[option]))
 
             if option == "qase_testops_run_id" and config.option.__dict__[option] is not None:
-                config_manager.config.testops.run.set_id(config.option.__dict__[option])
+                config_manager.config.testops.run.set_id(int(config.option.__dict__[option]))
 
             if option == "qase_testops_run_title" and config.option.__dict__[option] is not None:
                 config_manager.config.testops.run.set_title(config.option.__dict__[option])
@@ -109,7 +109,7 @@ def setup_config_manager(config):
                 config_manager.config.testops.batch.set_size(int(config.option.__dict__[option]))
 
             if option == "qase_pytest_capture_logs" and config.option.__dict__[option] is not None:
-                config_manager.config.pytest.set_capture_logs(config.option.__dict__[option])
+                config_manager.config.framework.pytest.set_capture_logs(config.option.__dict__[option])
 
     return config_manager
 

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -170,7 +170,7 @@ class QasePytestOptions:
             parser,
             group,
             "--qase-pytest-capture-logs",
-            dest="qase-pytest-capture-logs",
+            dest="qase_pytest_capture_logs",
             type="bool",
             help="Capture logs from pytest"
         )


### PR DESCRIPTION
Fixed an issue then `qase-pytest-capture-logs` parameter did not set correct value.

Fix #234