### PR TITLE
feature: execution of selected tests

### DIFF
--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.0.3"
+version = "6.0.4"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.0.2",
+    "qase-python-commons~=3.0.4",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -48,7 +48,7 @@ class QasePytestPlugin:
         self.runtime = Runtime()
         self.reporter = reporter
         self.run_id = None
-        self.execution_plan = None
+        self.execution_plan = reporter.get_execution_plan()
 
         self.reporter.setup_profilers(runtime=self.runtime)
 


### PR DESCRIPTION
If you use the `testops` mode and specify a plan ID then the reporter will run the tests specified in the test plan based on their IDs.