### PR TITLE
fix: exclude default parameters

### DIFF
--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.0.4"
+version = "6.0.5"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -265,6 +265,8 @@ class QasePytestPlugin:
     def _set_params(self, item) -> None:
         if hasattr(item, 'callspec'):
             for key, val in item.callspec.params.items():
+                if key.startswith("__pytest"):
+                    continue
                 self.runtime.result.add_param(key, str(val))
 
     def _set_suite(self, item) -> None:


### PR DESCRIPTION
Exclude the default parameters that are added by additional libraries and start with "__pytest"