### PR TITLE
fix: an issue with `report` mode

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.0.4"
+version = "3.0.5"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -117,8 +117,8 @@ class QaseReport:
         self._store_object(run, self.report_path, "report")
 
     # Saves a model to a file
-    def _store_object(self, object, path, filename):
-        data = object.to_json()
+    def _store_object(self, obj, path, filename):
+        data = obj.__str__()
         if self.format == 'jsonp':
             data = f"qaseJsonp({data});"
         with open(f"{path}/{filename}.{self.format}", 'w', encoding='utf-8') as f:


### PR DESCRIPTION
The error occurs when running tests in `report` mode: `'Result' object has no attribute 'to_json'`