### PR TITLE
fix: send all fields

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-python-commons@3.1.0b6
+
+## What's new
+
+Reporters didn't send information about fields, like `title`, `description`, etc, to the Qase. 
+Now, the reporters will send all the information about the test case to the Qase.
+
 # qase-python-commons@3.1.0b4
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.0b5"
+version = "3.1.0b6"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -186,17 +186,13 @@ class ApiV1Client(BaseApiClient):
             "steps": steps,
             "param": result.params,
             "defect": self.config.testops.defect,
+            "case": case_data
         }
 
         test_ops_id = result.get_testops_id()
 
         if test_ops_id:
             result_model["case_id"] = test_ops_id
-            result_model["case"] = None
-            return result_model
-
-        result_model["case_id"] = None
-        result_model["case"] = case_data
 
         self.logger.log_debug(f"Prepared result: {result_model}")
 


### PR DESCRIPTION
Reporters didn't send information about fields, like `title`, `description`, etc, to the Qase. 
Now, the reporters will send all the information about the test case to the Qase.