### PR TITLE
fix: execution of selected tests and default parameters

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.0b4
+
+## What's new
+
+- Exclude the default parameters that are added by additional libraries and start with `__pytest`
+- If you use the `testops` mode and specify a plan ID then the reporter will run the tests specified in the test plan based on their IDs.
+
 # qase-pytest 6.1.0b3
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.0b3"
+version = "6.1.0b4"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.0b1",
+    "qase-python-commons~=3.1.0b6",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -48,7 +48,7 @@ class QasePytestPlugin:
         self.runtime = Runtime()
         self.reporter = reporter
         self.run_id = None
-        self.execution_plan = None
+        self.execution_plan = reporter.get_execution_plan()
 
         self.reporter.setup_profilers(runtime=self.runtime)
 
@@ -268,6 +268,8 @@ class QasePytestPlugin:
     def _set_params(self, item) -> None:
         if hasattr(item, 'callspec'):
             for key, val in item.callspec.params.items():
+                if key.startswith("__pytest"):
+                    continue
                 self.runtime.result.add_param(key, str(val))
 
     def _set_suite(self, item) -> None:


### PR DESCRIPTION
- Exclude the default parameters that are added by additional libraries and start with `__pytest`
- If you use the `testops` mode and specify a plan ID then the reporter will run the tests specified in the test plan based on their IDs.