### PR TITLE
fix: issue with client

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,13 @@
+# qase-python-commons@3.1.0b7
+
+## What's new
+
+Fixed the following issue:
+
+```log
+HTTPSConnectionPool(host='api.qase.io', port=443): Max retries exceeded with url: /v1/plan/DEMO/1 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)')))
+```
+
 # qase-python-commons@3.1.0b6
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.0b6"
+version = "3.1.0b7"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/loader.py
+++ b/qase-python-commons/src/qase/commons/loader.py
@@ -11,11 +11,10 @@ class TestOpsPlanLoader:
         configuration = Configuration()
         configuration.api_key['TokenAuth'] = api_token
         configuration.host = f'https://api.{host}/v1'
+        configuration.ssl_ca_cert = certifi.where()
 
         self.client = ApiClient(configuration)
         self.case_list = []
-
-        configuration.ssl_ca_cert = certifi.where()
 
     def load(self, code: str, plan_id: int) -> list:
         try:


### PR DESCRIPTION
Fixed the following issue:

`
HTTPSConnectionPool(host='api.qase.io', port=443): Max retries exceeded with url: /v1/plan/DEMO/1 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1000)'))) `