### PR TITLE
release: qase-python-commons 3.1.0

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-python-commons@3.1.0
+
+## What's new
+
+Minor release that includes all changes from beta versions 3.1.0b*. 
+Also added support for group parameters.
+
 # qase-python-commons@3.1.0b7
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.0b7"
+version = "3.1.0"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -30,7 +30,7 @@ requires-python = ">=3.7"
 dependencies = [
     "certifi>=2024.2.2",
     "attrs>=23.2.0",
-    "qase-api-client~=1.0.1",
+    "qase-api-client~=1.1.0",
     "qase-api-v2-client~=1.0.0",
     "more_itertools"
 ]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -185,6 +185,7 @@ class ApiV1Client(BaseApiClient):
             "attachments": [attach.hash for attach in attached],
             "steps": steps,
             "param": result.params,
+            "param_groups": result.param_groups,
             "defect": self.config.testops.defect,
             "case": case_data
         }

--- a/qase-python-commons/src/qase/commons/models/result.py
+++ b/qase-python-commons/src/qase/commons/models/result.py
@@ -1,9 +1,7 @@
 import time
 import uuid
-import json
 
 from typing import Type, Optional, Union, Dict, List
-from pathlib import PosixPath
 from .basemodel import BaseModel
 from .step import Step
 from .suite import Suite
@@ -79,6 +77,7 @@ class Result(BaseModel):
         self.attachments: List[Attachment] = []
         self.steps: List[Type[Step]] = []
         self.params: Optional[dict] = {}
+        self.param_groups: Optional[List[List[str]]] = []
         self.author: Optional[str] = None
         self.relations: List[Type[Relation]] = []
         self.muted: bool = False
@@ -103,6 +102,9 @@ class Result(BaseModel):
 
     def add_param(self, key: str, value: str) -> None:
         self.params[key] = value
+
+    def add_param_groups(self, values: List[str]) -> None:
+        self.param_groups.append(values)
 
     def add_relation(self, relation: Type[Relation]) -> None:
         self.relations.append(relation)


### PR DESCRIPTION
Minor release that includes all changes from beta versions 3.1.0b*. 
Also added support for group parameters.