### PR TITLE
release: qase-pytest 6.1.0

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.0
+
+## What's new
+
+Minor release that includes all changes from beta versions 6.1.0b. 
+And also added support for group parameters.
+
 # qase-pytest 6.1.0b4
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.0b4"
+version = "6.1.0"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.0b6",
+    "qase-python-commons~=3.1.0",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",


### PR DESCRIPTION
Minor release that includes all changes from beta versions 6.1.0b. And also added support for group parameters.