### PR TITLE
feature: Add support `robotframework-tidy`

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 3.1.1b1
+
+## What's new
+
+Add support `robotframework-tidy` to the reporter. 
+The reporter will ignore `IF`, `ELSE IF`, `ELSE`, and `END` keywords.
+
 # qase-pytest 3.1.0
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.1.0"
+version = "3.1.1b1"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -89,6 +89,9 @@ class Listener:
         )
 
     def start_keyword(self, name, attributes):
+        if attributes["type"] != "KEYWORD" or attributes["status"] == "NOT RUN":
+            return
+
         id = str(uuid.uuid4())
         step = Step(
             step_type=StepType.GHERKIN,
@@ -100,6 +103,9 @@ class Listener:
         self.step_uuid = id
 
     def end_keyword(self, name, attributes):
+        if attributes["type"] != "KEYWORD" or attributes["status"] == "NOT RUN":
+            return
+
         self.runtime.finish_step(self.step_uuid, STATUSES[attributes["status"]])
         self.step_uuid = self.runtime.steps[self.step_uuid].parent_id
 


### PR DESCRIPTION
The reporter will ignore `IF`, `ELSE IF`, `ELSE`, and `END` keywords.
[#247]