### PR TITLE
feature: Support `pytest-rerunfailures` plugin

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.1b1
+
+## What's new
+
+Support `pytest-rerunfailures` plugin. This plugin allows you to rerun failed tests.
+Each test run will be uploaded as a separate result in Qase.
+
 # qase-pytest 6.1.0
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.0"
+version = "6.1.1b1"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]


### PR DESCRIPTION
This plugin allows you to rerun failed tests.
Each test run will be uploaded as a separate result in Qase.

[#246]