### PR TITLE
feature: upload video for failed tests

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,24 @@
+# qase-pytest 6.1.1b2
+
+## What's new
+
+If the video recording option is enabled and the test fails, the video will be attached to the test result when using Playwright.
+
+For configuration, you should create a `conftest.py` file in the root of your project and add the following code:
+
+```python
+import pytest
+
+# Configure Playwright to record video for all tests
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    return {
+        **browser_context_args,
+        "record_video_dir": "./videos",  # Directory where videos will be saved
+        "record_video_size": {"width": 1280, "height": 720}  # Video resolution
+    }
+```
+
 # qase-pytest 6.1.1b1
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.1b1"
+version = "6.1.1b2"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.0",
+    "qase-python-commons~=3.1.1",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -167,6 +167,14 @@ class QasePytestPlugin:
 
             if self.reporter.config.framework.pytest.capture_logs and report.when == "call":
                 _attach_logs()
+
+            # Check if the test failed
+            if report.failed and report.when == "call":
+                # Attach the video to the test result
+                video = item.funcargs['page'].video
+                if not video:
+                    return
+                self.add_attachments(video.path())
         else:
             yield
 


### PR DESCRIPTION
If the video recording option is enabled and the test fails, the video will be attached to the test result when using Playwright.