### PR TITLE
release: qase-python-commons 3.1.2

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.1.2
+
+## What's new
+
+Support `suite` field in the test case model.
+
 # qase-python-commons@3.1.0
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.1"
+version = "3.1.2"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -170,12 +170,15 @@ class ApiV1Client(BaseApiClient):
         if result.get_suite_title():
             suite = "\t".join(result.get_suite_title().split("."))
 
+        if result.get_field('suite'):
+            suite = result.get_field('suite')
+
         root_suite = self.config.root_suite
         if root_suite:
             suite = f"{root_suite}\t{suite}"
 
         if suite:
-            case_data["suite"] = suite
+            case_data["suite_title"] = suite
 
         result_model = {
             "status": result.execution.status,


### PR DESCRIPTION
Support `suite` field in the test case model.

[#248]