### PR TITLE
fix: issue with parameters

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,4 +1,23 @@
-# qase-pytest 6.1.1b2
+# qase-pytest 6.1.1b4
+
+## What's new
+
+Fixed an issue with parameters like this:
+
+```python
+@pytest.mark.parametrize(argnames="foo", argvalues=["bar","baz"])
+```  
+
+The error was:
+
+```log
+INTERNALERROR> File "/usr/local/lib/python3.12/site-packages/qase/pytest/plugin.py", line 79, in pytest_collection_modifyitems
+INTERNALERROR> param_name, values = mark.args
+INTERNALERROR> ^^^^^^^^^^^^^^^^^^
+INTERNALERROR> ValueError: not enough values to unpack (expected 2, got 0)
+```
+
+# qase-pytest 6.1.1b3
 
 ## What's new
 

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.1b3"
+version = "6.1.1b4"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -78,9 +78,14 @@ class QasePytestPlugin:
             # Extract single and grouped params from the item's markers
             for mark in item.iter_markers():
                 if mark.name == 'parametrize':
-                    param_name, values = mark.args
-                    if ',' in param_name:
-                        grouped_params.append(param_name.split(','))
+                    if len(mark.args) != 0:
+                        param_name, values = mark.args
+                        if ',' in param_name:
+                            grouped_params.append(param_name.split(','))
+                    else:
+                        param_name = mark.kwargs.get('argnames')
+                        if ',' in param_name:
+                            grouped_params.append(param_name.split(','))
 
             # Attach the captured params to the test item
             item._grouped_params = grouped_params


### PR DESCRIPTION
If we use parameters like this `pytest.mark.parametrize(argnames="foo", argvalues=["bar","baz"])`, then get an error:

```log
INTERNALERROR> File "/usr/local/lib/python3.12/site-packages/qase/pytest/plugin.py", line 79, in pytest_collection_modifyitems
INTERNALERROR> param_name, values = mark.args
INTERNALERROR> ^^^^^^^^^^^^^^^^^^
INTERNALERROR> ValueError: not enough values to unpack (expected 2, got 0)
```

[#264 ]