### PR TITLE
feature: support `ignore` tag

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,11 @@
+# qase-pytest 3.1.1
+
+## What's new
+
+Minor release that includes all changes from beta versions 3.1.1b.
+
+Support `ignore` tag. If the test has the `ignore` tag, the reporter will not send the result to Qase.
+
 # qase-pytest 3.1.1b2
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.1.1b2"
+version = "3.1.1"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -17,7 +17,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.0",
+    "qase-python-commons~=3.1.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
If the test has the `ignore` tag, the reporter will not send the result to Qase.