### PR TITLE
feature: support `qase.fields` tag

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,10 +1,28 @@
+# qase-pytest 3.1.2
+
+## What's new
+
+Support `qase.fields` tag. You can specify the fields that you want to send to Qase.
+
+```robotframework
+Simple test
+    [Tags]     qase.fields:{ "suite": "my suite", "description": "It is simple test" }
+    Should Be Equal As Numbers    1    1
+```
+
 # qase-pytest 3.1.1
 
 ## What's new
 
 Minor release that includes all changes from beta versions 3.1.1b.
 
-Support `ignore` tag. If the test has the `ignore` tag, the reporter will not send the result to Qase.
+Support `qase.ignore` tag. If the test has the `qase.ignore` tag, the reporter will not send the result to Qase.
+
+```robotframework
+Simple test
+    [Tags]     qase.ignore
+    Should Be Equal As Numbers    1    1
+```
 
 # qase-pytest 3.1.1b2
 

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.1.1"
+version = "3.1.2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/models.py
+++ b/qase-robotframework/src/qase/robotframework/models.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List
+from typing import List, Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -85,3 +85,14 @@ class EndKeywordModel(TypedDict):
     endtime: str
     elapsedtime: int
     status: str
+
+
+class TestMetadata:
+    qase_id: Union[int, None]
+    ignore: bool
+    fields: dict
+
+    def __init__(self) -> None:
+        self.qase_id = None
+        self.ignore = False
+        self.fields = {}

--- a/qase-robotframework/src/qase/robotframework/tag_parser.py
+++ b/qase-robotframework/src/qase/robotframework/tag_parser.py
@@ -1,0 +1,41 @@
+import json
+import logging
+import re
+
+from .models import TestMetadata
+
+
+class TagParser:
+    __logger = logging.getLogger("qase-robotframework")
+
+    @staticmethod
+    def parse_tags(tags: list[str]) -> TestMetadata:
+        metadata = TestMetadata()
+        for tag in tags:
+            if tag.lower().startswith("q-"):
+                metadata.qase_id = TagParser.__extract_ids(tag)
+
+            if tag.lower() == "qase.ignore":
+                metadata.ignore = True
+
+            if tag.lower().startswith("qase.fields"):
+                metadata.fields = TagParser.__extract_fields(tag)
+
+        return metadata
+
+    @staticmethod
+    def __extract_ids(tag: str) -> int or None:
+        qase_id = re.compile(r"Q-(\d+)", re.IGNORECASE)
+        if qase_id.fullmatch(tag):
+            return int(qase_id.match(tag).groups()[0])
+
+        return None
+
+    @staticmethod
+    def __extract_fields(tag: str) -> dict:
+        value = tag.split(':', 1)[-1].strip()
+        try:
+            return json.loads(value)
+        except ValueError as e:
+            TagParser.__logger.error(f"Error parsing fields from tag '{tag}': {e}")
+            return {}


### PR DESCRIPTION
You can specify the fields that you want to send to Qase.

```robotframework
Simple test
    [Tags]     qase.fields:{ "suite": "my suite", "description": "It is simple test" }
    Should Be Equal As Numbers    1    1
```