### PR TITLE
feature: support selective execution

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -2,7 +2,9 @@
 
 ## What's new
 
-Migrate the listener to the `ROBOT_LISTENER_API_VERSION` version 3.
+- Migrate the listener to the `ROBOT_LISTENER_API_VERSION` version 3.
+- Support a selective execution of tests by Qase ID.
+  If the plan id is specified, the reporter will send the results only for the tests that are in the plan.
 
 # qase-pytest 3.1.2
 

--- a/qase-robotframework/requirements.txt
+++ b/qase-robotframework/requirements.txt
@@ -1,1 +1,3 @@
-qase-python-commons=3.0.3
+qase-python-commons~=3.1.3
+
+robotframework~=7.1

--- a/qase-robotframework/src/qase/robotframework/filter.py
+++ b/qase-robotframework/src/qase/robotframework/filter.py
@@ -1,0 +1,26 @@
+from robot.api import SuiteVisitor
+
+from .tag_parser import TagParser
+
+
+class Filter(SuiteVisitor):
+
+    def __init__(self, *tests):
+        self.tests = tests
+
+    def start_suite(self, suite):
+        suite.tests = [t for t in suite.tests if self._is_included(t)]
+
+    def _is_included(self, test):
+        test_metadata = TagParser.parse_tags(test.tags)
+
+        if test_metadata.qase_id:
+            return test_metadata.qase_id in self.tests
+
+        return False
+
+    def end_suite(self, suite):
+        suite.suites = [s for s in suite.suites if s.test_count > 0]
+
+    def visit_test(self, test):
+        pass

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -6,6 +6,7 @@ from qase.commons.models import Result, Suite, Step, Field
 from qase.commons.models.step import StepType, StepGherkinData
 from qase.commons.reporters import QaseCoreReporter
 
+from .filter import Filter
 from .plugin import QaseRuntimeSingleton
 from .tag_parser import TagParser
 from .types import STATUSES
@@ -23,7 +24,6 @@ class Listener:
         self.runtime = QaseRuntimeSingleton.get_instance()
         self.step_uuid = None
         self.tests = {}
-        self.suite = {}
 
         if config.config.debug:
             logger.setLevel(logging.DEBUG)
@@ -37,6 +37,11 @@ class Listener:
         self.reporter.start_run()
 
     def start_suite(self, suite, result):
+        execution_plan = self.reporter.get_execution_plan()
+        if execution_plan:
+            selector = Filter(*execution_plan)
+            suite.visit(selector)
+
         self.tests.update(self.__extract_tests_with_suites(suite))
 
     def start_test(self, test, result):


### PR DESCRIPTION
If the plan id is specified, the reporter will send the results only for the tests that are in the plan.