### PR TITLE
feature: improve handling of nested steps

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,19 @@
+# qase-pytest 3.2.0b3
+
+## What's new
+
+Improve handling of nested steps in the Robot Framework listener.
+
+For example, if the test has the following structure:
+
+```robotframework
+Formatted Return
+    RETURN  ${value}
+```
+
+Previously, the `RETURN` keyword was presented as `RETURN` in the Qase test run. 
+Now, the keyword is presented as `RETURN  ${value}`.
+
 # qase-pytest 3.2.0b2
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.2.0b2"
+version = "3.2.0b3"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -133,6 +133,8 @@ class Listener:
 
             if hasattr(result.body[i], "type") and result.body[i].type != "KEYWORD":
                 step_name = result.body[i].type
+                if hasattr(result.body[i], "values"):
+                    step_name += " " + " ".join(result.body[i].values)
             else:
                 step_name = result.body[i].name
 


### PR DESCRIPTION
Previously, the `RETURN` keyword was presented as `RETURN` in the Qase test run. 
Now, the keyword is presented as `RETURN  ${value}`.