### PR TITLE
refactor : runtime model

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.1.4
+
+## What's new
+
+Add `clear` method to set the runtime to the base state. 
+
 # qase-python-commons@3.1.3
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.3"
+version = "3.1.4"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/models/runtime.py
+++ b/qase-python-commons/src/qase/commons/models/runtime.py
@@ -1,4 +1,4 @@
-from .step import Step, StepTextData
+from .step import Step
 from .attachment import Attachment
 
 
@@ -41,3 +41,8 @@ class Runtime:
                 self.result.add_attachment(attachment)
         except Exception as e:
             raise QaseRuntimeException(e)
+
+    def clear(self):
+        self.result = None
+        self.steps = {}
+        self.step_id = None


### PR DESCRIPTION
Add `clear` method to set the runtime to the base state