### PR TITLE
fix: an issue with the `pytest-xdist`

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.2
+
+## What's new
+
+Fixed an issue with the `pytest-xdist` that caused the tests to be run in parallel and completed the test run before the
+results were uploaded to Qase.
+
 # qase-pytest 6.1.1
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.1"
+version = "6.1.2"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -112,7 +112,8 @@ class QasePytestPlugin:
         else:
             self.reporter.complete_worker()
 
-        self.reporter.complete_run()
+        if QasePytestPlugin.meta_run_file.exists() == False:
+            self.reporter.complete_run()
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item):


### PR DESCRIPTION
Fixed an issue with the `pytest-xdist` that caused the tests to be run in parallel and completed the test run before the results were uploaded to Qase.