### PR TITLE
fix : change logic for uploading attachments

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,4 +1,11 @@
-# qase-python-commons@3.1.4
+# qase-python-commons@3.1.6
+
+## What's new
+
+Change logic for uploading attachments. Now, the `upload_attachment` method won't return an error if the file is not
+found.
+
+# qase-python-commons@3.1.5
 
 ## What's new
 
@@ -28,7 +35,7 @@ Support `suite` field in the test case model.
 
 ## What's new
 
-Minor release that includes all changes from beta versions 3.1.0b*. 
+Minor release that includes all changes from beta versions 3.1.0b*.
 Also added support for group parameters.
 
 # qase-python-commons@3.1.0b7
@@ -45,7 +52,7 @@ HTTPSConnectionPool(host='api.qase.io', port=443): Max retries exceeded with url
 
 ## What's new
 
-Reporters didn't send information about fields, like `title`, `description`, etc, to the Qase. 
+Reporters didn't send information about fields, like `title`, `description`, etc, to the Qase.
 Now, the reporters will send all the information about the test case to the Qase.
 
 # qase-python-commons@3.1.0b4

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.1.5"
+version = "3.1.6"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -88,8 +88,8 @@ class ApiV1Client(BaseApiClient):
             return response.result
 
         except Exception as e:
-            self.logger.log(f"Error at uploading attachment: {e}", "error")
-            raise ReporterException(e)
+            self.logger.log(f"Error at uploading attachment: {e}", "debug")
+            return None
 
     def create_test_run(self, project_code: str, title: str, description: str, plan_id=None,
                         environment_id=None) -> str:
@@ -139,7 +139,9 @@ class ApiV1Client(BaseApiClient):
         attached = []
         if result.attachments:
             for attachment in result.attachments:
-                attached.extend(self._upload_attachment(project_code, attachment))
+                attach_id = self._upload_attachment(project_code, attachment)
+                if attach_id:
+                    attached.append(attach_id)
 
         steps = []
         for step in result.steps:
@@ -252,7 +254,9 @@ class ApiV1Client(BaseApiClient):
             if step.attachments:
                 uploaded_attachments = []
                 for file in step.attachments:
-                    uploaded_attachments.extend(self._upload_attachment(project_code, file))
+                    attach_id = self._upload_attachment(project_code, file)
+                    if attach_id:
+                        uploaded_attachments.append(attach_id)
                 prepared_step['attachments'] = [attach.hash for attach in uploaded_attachments]
 
             if step.steps:


### PR DESCRIPTION
Now, the `upload_attachment` method won't return an error if the file is not found.