### PR TITLE
feature: improve video handling in Playwright

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,13 @@
+# qase-pytest 6.1.3
+
+## What's new
+
+If a video is attached to the result, it will be added as an attachment.
+You can configure this functionality using the "video" parameter:
+
+- `--video on` - add a video to each test
+- `--video retain-on-failure` - add a video to each filed test
+
 # qase-pytest 6.1.2
 
 ## What's new
@@ -15,7 +25,7 @@ Minor release that includes all changes from beta versions 6.1.1b.
 
 ## What's new
 
-Fixed an issue with `network` profiler. 
+Fixed an issue with `network` profiler.
 
 # qase-pytest 6.1.1b4
 
@@ -24,7 +34,7 @@ Fixed an issue with `network` profiler.
 Fixed an issue with parameters like this:
 
 ```python
-@pytest.mark.parametrize(argnames="foo", argvalues=["bar","baz"])
+@pytest.mark.parametrize(argnames="foo", argvalues=["bar", "baz"])
 ```  
 
 The error was:

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.2"
+version = "6.1.3"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.5",
+    "qase-python-commons~=3.1.8",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -174,8 +174,7 @@ class QasePytestPlugin:
             if self.reporter.config.framework.pytest.capture_logs and report.when == "call":
                 _attach_logs()
 
-            # Check if the test failed
-            if report.failed and report.when == "call":
+            if report.when == "call":
                 # Attach the video to the test result
                 if hasattr(item, 'funcargs') and 'page' in item.funcargs:
                     video = item.funcargs['page'].video


### PR DESCRIPTION
If a video is attached to the result, it will be added as an attachment. You can configure this functionality using the "video" parameter:

- `--video on` - add a video to each test
- `--video retain-on-failure` - add a video to each filed test

#279