### PR TITLE
release: qase-pytest 6.1.4

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,4 +1,4 @@
-# qase-pytest 6.1.4b1
+# qase-pytest 6.1.4
 
 ## What's new
 

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,17 @@
+# qase-pytest 6.1.4b1
+
+## What's new
+
+Improve handling parameters in the `pytest.mark.parametrize` decorator.
+If you specify the `ids` parameter, the reporter will use it as value of parameter in the test case.
+
+```python
+@pytest.mark.parametrize("enter", [enter_from_meta, enter_from_expedition, enter_from_news],
+                         ids=["enter_from_meta", "enter_from_expedition", "enter_from_news"])
+def test_enter(enter):
+    enter()
+```
+
 # qase-pytest 6.1.3
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.4b1"
+version = "6.1.4"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.3"
+version = "6.1.4b1"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -308,10 +308,14 @@ class QasePytestPlugin:
             for group in item._grouped_params:
                 self.runtime.result.add_param_groups(group)
 
+            ids = item.callspec.id.split("-")
+            i = 0
             for key, val in item.callspec.params.items():
+                value = str(ids[i])
+                i += 1
                 if key.startswith("__pytest"):
                     continue
-                self.runtime.result.add_param(key, str(val))
+                self.runtime.result.add_param(key, value)
 
     def _set_suite(self, item) -> None:
         marker = item.get_closest_marker("qase_suite")


### PR DESCRIPTION
feature: improve handling parameters in the pytest.mark.parametrize decorator.

If you specify the `ids` parameter, the reporter will use it as value of parameter in the test case.

```python
@pytest.mark.parametrize("enter", [enter_from_meta, enter_from_expedition, enter_from_news],
                         ids=["enter_from_meta", "enter_from_expedition", "enter_from_news"])
def test_enter(enter):
    enter()
```