### PR TITLE
feature: improve the handling of videos and traces for Playwright tests

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,19 @@
+# qase-pytest 6.1.5
+
+## What's new
+
+Improved the handling of videos and traces for Playwright tests.
+You don't need to create a `conftest.py` file anymore. The video and trace will be attached to the test result
+automatically.
+You can configure the video and trace recording using the following parameters:
+
+- `--video on` - add a video to each test
+- `--video retain-on-failure` - add a video to each filed test
+- `--tracing on` - add a trace to each test
+- `--tracing retain-on-failure` - add a trace to each filed test
+- `--output` - the directory where the video and trace will be saved. By default, the video and trace will be saved in
+  the `test-results` directory.
+
 # qase-pytest 6.1.4
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.4"
+version = "6.1.5"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.1.8",
+    "qase-python-commons~=3.1.9",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -47,6 +47,15 @@ def _add_markers(config):
 def setup_config_manager(config):
     config_manager = ConfigManager()
     for option in config.option.__dict__:
+        if option == "output" and config.option.__dict__[option] is not None:
+            config_manager.config.framework.playwright.set_output_dir(config.option.__dict__[option])
+
+        if option == "video" and config.option.__dict__[option] is not None:
+            config_manager.config.framework.playwright.set_video(config.option.__dict__[option])
+
+        if option == "tracing" and config.option.__dict__[option] is not None:
+            config_manager.config.framework.playwright.set_trace(config.option.__dict__[option])
+
         if option.startswith("qase_"):
             if option == "qase_mode" and config.option.__dict__[option] is not None:
                 config_manager.config.set_mode(config.option.__dict__[option])


### PR DESCRIPTION
You don't need to create a `conftest.py` file anymore. The video and trace will be attached to the test result automatically.
You can configure the video and trace recording using the following parameters:

- `--video on` - add a video to each test
- `--video retain-on-failure` - add a video to each filed test
- `--tracing on` - add a trace to each test
- `--tracing retain-on-failure` - add a trace to each filed test
- `--output` - the directory where the video and trace will be saved. By default, the video and trace will be saved in the `test-results` directory.