### PR TITLE
fix: an issue with the handling video and trace recording

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.6
+
+## What's new
+
+Fixed an issue with the handling video and trace recording for Playwright tests. If a test was part of a class, the video
+and trace were not attached to the test result.
+
 # qase-pytest 6.1.5
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.5"
+version = "6.1.6"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -358,13 +358,23 @@ class QasePytestPlugin:
 
     @staticmethod
     def __build_folder_name(item):
-        return (
-                item.location[0].replace(os.sep, "-").replace(".", "-").replace("_", "-")
-                + "-"
-                + item.originalname.replace(".", "-").replace("_", "-")
-                + "-"
-                + item.funcargs['browser_name']
+        path_parts = [QasePytestPlugin.__sanitize_path_component(item.location[0])]
+
+        if '.' in item.location[2]:
+            path_parts.append(
+                QasePytestPlugin.__sanitize_path_component(item.location[2].split('.')[0])
+            )
+
+        path_parts.append(
+            QasePytestPlugin.__sanitize_path_component(item.originalname)
         )
+        path_parts.append(item.funcargs['browser_name'])
+
+        return "-".join(path_parts)
+
+    @staticmethod
+    def __sanitize_path_component(component):
+        return component.replace(os.sep, "-").replace(".", "-").replace("_", "-").lower()
 
 
 class QasePytestPluginSingleton:


### PR DESCRIPTION
If a test was part of a class, the video and trace were not attached to the test result.

#279