### PR TITLE
feature: support `pabot`

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,11 @@
+# qase-pytest 3.2.0
+
+## What's new
+
+Minor release that includes all changes from beta versions 3.2.0b.
+
+Support `pabot` library. If you use the `pabot` library to run tests in parallel, the reporter will send the results
+
 # qase-pytest 3.2.0b3
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.2.0b3"
+version = "3.2.0"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -18,6 +18,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-r
 requires-python = ">=3.7"
 dependencies = [
     "qase-python-commons~=3.1.3",
+    "filelock~=3.12.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
If you use the `pabot` library to run tests in parallel, the reporter will send the results