### PR TITLE
feat : use the API v2 client by default

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -2,6 +2,13 @@
 
 ## What's new
 
+Use the API v2 client by default. If you want to use the API v1 client, specify the `useV2` option in the config file or
+the environment variable `QASE_TESTOPS_USEV2` as `False`.
+
+# qase-python-commons@3.2.0
+
+## What's new
+
 Updated the `file` reporter and support new API v2 client
 
 # qase-python-commons@3.1.9

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.2.0"
+version = "3.2.1"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/models/config/testops.py
+++ b/qase-python-commons/src/qase/commons/models/config/testops.py
@@ -20,7 +20,7 @@ class TestopsConfig(BaseModel):
         self.batch = BatchConfig()
         self.plan = PlanConfig()
         self.defect = False
-        self.use_v2 = False
+        self.use_v2 = True
 
     def set_project(self, project: str):
         self.project = project


### PR DESCRIPTION
If you want to use the API v1 client, specify the `useV2` option in the config file or the environment variable `QASE_TESTOPS_USEV2` as `False`.