### PR TITLE
feat: support `qase.params` tag

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,4 +1,4 @@
-# qase-python-commons@3.2.0
+# qase-python-commons@3.2.1
 
 ## What's new
 

--- a/qase-robotframework/README.md
+++ b/qase-robotframework/README.md
@@ -29,7 +29,7 @@ Configuration options are described in the
 
 ```json
 {
-  "mode": "testops", 
+  "mode": "testops",
   "fallback": "report",
   "debug": true,
   "testops": {
@@ -45,12 +45,12 @@ Configuration options are described in the
       "size": 100
     }
   },
-    "report": {
+  "report": {
     "driver": "local",
     "connection": {
       "local": {
         "path": "./build/qase-report",
-        "format": "json" 
+        "format": "json"
       }
     }
   },
@@ -58,12 +58,12 @@ Configuration options are described in the
 }
 ```
 
-
 ## Usage
 
 ### Link tests with test cases in Qase TestOps
 
-To link the automated tests with the test cases in Qase TestOps, use the tags in form like `Q-<case id without project code>`.
+To link the automated tests with the test cases in Qase TestOps, use the tags in form like
+`Q-<case id without project code>`.
 Example:
 
 ```robotframework
@@ -96,6 +96,7 @@ Subtraction           12 - 2 - 2    8
 Listener supports reporting steps results:
 
 Example:
+
 ```robotframework
 Quick Get A JSON Body Test                                                  ## Test case: "Quick Get A JSON Body Test"
     [Tags]  Q-3
@@ -107,7 +108,30 @@ Initializing the test case                                                  ## T
     Set To Dictionary    ${info}   field1=A sample string                   ## 1-st step - "Set To Dictionary"
 ```
 
+### Working with parameters
+
+Listener supports reporting parameters:
+
+Example:
+
+```robotframework
+*** Variables ***
+${var1}            1
+${var2}            1
+${var3}            2
+
+*** Test Cases ***
+Simple test
+    [Arguments]    ${var1}    ${var2}   ${var3}
+    [Tags]     qase.params:[var1, var2]
+    Should Be Equal As Numbers    ${var1}    ${var2}
+    Should Be Equal As Numbers    ${var3}    ${var3} 
+```
+
+Only `var1` and `var2` will be sent to Qase.
+
 ### Execution:
+
 ```
 robot --listener qase.robotframework.Listener someTest.robot
 ```

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,25 @@
+# qase-robotframework 3.2.2
+
+## What's new
+
+Support `qase.params` tag. You can specify the params that you want to send to Qase.
+
+```robotframework
+*** Variables ***
+${var1}            1
+${var2}            1
+${var3}            2
+
+*** Test Cases ***
+Simple test
+    [Arguments]    ${var1}    ${var2}   ${var3}
+    [Tags]     qase.params:[var1, var2]
+    Should Be Equal As Numbers    ${var1}    ${var2}
+    Should Be Equal As Numbers    ${var3}    ${var3} 
+```
+
+Only `var1` and `var2` will be sent to Qase.
+
 # qase-robotframework 3.2.1
 
 ## What's new
@@ -25,7 +47,7 @@ Formatted Return
     RETURN  ${value}
 ```
 
-Previously, the `RETURN` keyword was presented as `RETURN` in the Qase test run. 
+Previously, the `RETURN` keyword was presented as `RETURN` in the Qase test run.
 Now, the keyword is presented as `RETURN  ${value}`.
 
 # qase-robotframework 3.2.0b2

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.2.1"
+version = "3.2.2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -17,7 +17,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.2.0",
+    "qase-python-commons~=3.2.1",
     "filelock~=3.12.2",
 ]
 

--- a/qase-robotframework/src/qase/robotframework/models.py
+++ b/qase-robotframework/src/qase/robotframework/models.py
@@ -91,8 +91,10 @@ class TestMetadata:
     qase_id: Union[int, None]
     ignore: bool
     fields: dict
+    params: list[str]
 
     def __init__(self) -> None:
         self.qase_id = None
         self.ignore = False
         self.fields = {}
+        self.params = []

--- a/qase-robotframework/src/qase/robotframework/tag_parser.py
+++ b/qase-robotframework/src/qase/robotframework/tag_parser.py
@@ -21,6 +21,9 @@ class TagParser:
             if tag.lower().startswith("qase.fields"):
                 metadata.fields = TagParser.__extract_fields(tag)
 
+            if tag.lower().startswith("qase.params"):
+                metadata.params = TagParser.__extract_params(tag)
+
         return metadata
 
     @staticmethod
@@ -39,3 +42,13 @@ class TagParser:
         except ValueError as e:
             TagParser.__logger.error(f"Error parsing fields from tag '{tag}': {e}")
             return {}
+
+    @staticmethod
+    def __extract_params(tag: str) -> list[str]:
+        value = tag.split(':', 1)[-1].strip()
+        try:
+            return [item.strip() for item in value[1:-1].split(",")]
+            # return value.replace('[', '').replace(']', '').split(',')
+        except ValueError as e:
+            TagParser.__logger.error(f"Error parsing params from tag '{tag}': {e}")
+            return []


### PR DESCRIPTION
You can specify the params that you want to send to Qase.

```robotframework
*** Variables ***
${var1}            1
${var2}            1
${var3}            2

*** Test Cases ***
Simple test
    [Arguments]    ${var1}    ${var2}   ${var3}
    [Tags]     qase.params:[var1, var2]
    Should Be Equal As Numbers    ${var1}    ${var2}
    Should Be Equal As Numbers    ${var3}    ${var3}
```

Only `var1` and `var2` will be sent to Qase.