### PR TITLE
fix: resolve pabot issue with duplicated test runs and incomplete executions

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,11 @@
+# qase-robotframework 3.2.3
+
+## What's new
+
+Fixed an issue with Pabot
+Resolved an issue where test runs were sometimes duplicated or test executions failed to complete under certain
+conditions.
+
 # qase-robotframework 3.2.2
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.2.2"
+version = "3.2.3"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -23,6 +23,10 @@ def get_pool_id():
     return BuiltIn().get_variable_value('${PABOTQUEUEINDEX}', None)
 
 
+def get_last_level_flag():
+    return BuiltIn().get_variable_value('${PABOTISLASTEXECUTIONINPOOL}', None)
+
+
 class Listener:
     ROBOT_LISTENER_API_VERSION = 3
 
@@ -34,6 +38,7 @@ class Listener:
         self.runtime = QaseRuntimeSingleton.get_instance()
         self.tests = {}
         self.pabot_index = None
+        self.last_level_flag = None
 
         if config.config.debug:
             logger.setLevel(logging.DEBUG)
@@ -46,6 +51,7 @@ class Listener:
 
     def start_suite(self, suite, result):
         self.pabot_index = get_pool_id()
+        self.last_level_flag = get_last_level_flag()
         if self.pabot_index is not None:
             try:
                 if int(self.pabot_index) == 0:
@@ -134,8 +140,8 @@ class Listener:
         )
 
     def close(self):
-        if self.pabot_index is not None:
-            if int(self.pabot_index) == 0:
+        if self.last_level_flag is not None:
+            if int(self.last_level_flag) == 1:
                 Listener.drop_run_id()
             else:
                 self.reporter.complete_worker()


### PR DESCRIPTION
This pull request includes several changes to the `qase-robotframework` project aimed at fixing issues with Pabot and improving test execution handling. The most important changes include updating the version, modifying the `Listener` class to handle a new flag, and updating the changelog.

### Version Update:
* [`qase-robotframework/pyproject.toml`](diffhunk://#diff-0af540c11e659381732acbce538f4f9e5a8b2e35fb82931c0d64bce15809761cL7-R7): Updated the project version from `3.2.2` to `3.2.3`.

### Changelog Update:
* [`qase-robotframework/changelog.md`](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R8): Added an entry for version `3.2.3` detailing the fixed issues with Pabot and test execution.

### Listener Class Modifications:
* `qase-robotframework/src/qase/robotframework/listener.py`: 
  - Added a new method `get_last_level_flag` to retrieve the `${PABOTISLASTEXECUTIONINPOOL}` variable.
  - Updated the `__init__` method to initialize `self.last_level_flag`.
  - Modified the `start_suite` method to set `self.last_level_flag` using the new method.
  - Updated the `close` method to check `self.last_level_flag` instead of `self.pabot_index` for determining when to drop the run ID.