### PR TITLE
fix: update repository links in pyproject.toml

### DIFF
--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://qase.io"
-Repository = "https://github.com/qase-tms/qase-python/tree/master/qase-behave"
+Repository = "https://github.com/qase-tms/qase-python/tree/main/qase-behave"
 Documentation = "https://developers.qase.io"
 
 

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://qase.io"
-Repository = "https://github.com/qase-tms/qase-python/tree/master/qase-pytest"
+Repository = "https://github.com/qase-tms/qase-python/tree/main/qase-pytest"
 Documentation = "https://developers.qase.io"
 
 [project.entry-points.pytest11]

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
 ]
-urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-python-commons"}
+urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-python-commons"}
 requires-python = ">=3.7"
 dependencies = [
     "certifi>=2024.2.2",

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Framework :: Robot Framework",
     "Programming Language :: Python",
 ]
-urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/master/qase-robotframework"}
+urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
     "qase-python-commons~=3.2.1",

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://qase.io"
-Repository = "https://github.com/qase-tms/qase-python/tree/master/qase-tavern"
+Repository = "https://github.com/qase-tms/qase-python/tree/main/qase-tavern"
 Documentation = "https://developers.qase.io"
 
 [project.optional-dependencies]


### PR DESCRIPTION
#315 
This pull request updates the repository URLs in several `pyproject.toml` files to reflect the change from the "master" branch to the "main" branch. These changes ensure that the documentation and repository links are accurate and up-to-date.

Repository URL updates:

* [`qase-behave/pyproject.toml`](diffhunk://#diff-931cf7a616c4d6ee3bab9cbbf56462aa986af4d12491ffcb43b5ec50f50ee296L39-R39): Updated the repository URL to use the "main" branch.
* [`qase-pytest/pyproject.toml`](diffhunk://#diff-eed5955cc5fa2d784b80f72dfcdfc0377506f787ab2c7991c290250c19bb90bfL40-R40): Updated the repository URL to use the "main" branch.
* [`qase-python-commons/pyproject.toml`](diffhunk://#diff-58b0d6680262cbdcbf5891ee16e7c7551e879b6f6d713b15faf7535ef685f655L28-R28): Updated the repository URL to use the "main" branch.
* [`qase-robotframework/pyproject.toml`](diffhunk://#diff-0af540c11e659381732acbce538f4f9e5a8b2e35fb82931c0d64bce15809761cL17-R17): Updated the repository URL to use the "main" branch.
* [`qase-tavern/pyproject.toml`](diffhunk://#diff-3926f435e408e1c646bfa711cb34cdbfe0c6a73f733e424512ec80a01895237aL40-R40): Updated the repository URL to use the "main" branch.