### PR TITLE
feat: add support for custom xfail statuses in pytest

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,8 +1,19 @@
+# qase-python-commons@3.2.4
+
+## What's new
+
+- Support for custom statuses of xfail-marked tests in pytest.
+- Default statuses: `skipped` (failed xfail) and `passed` (successful xfail).
+- Configuration values can be set via `qase.config.json` or environment variables:
+  - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
+  - `QASE_PYTEST_XFAIL_STATUS_XPASS`
+
 # qase-python-commons@3.2.3
 
 ## What's new
 
-Updated the handling of Gherkin steps to concatenate `keyword` and `name` into the action field when they differ, providing
+Updated the handling of Gherkin steps to concatenate `keyword` and `name` into the action field when they differ,
+providing
 a more descriptive step action.
 
 # qase-python-commons@3.2.2

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.2.3"
+version = "3.2.4"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -145,6 +145,19 @@ class ConfigManager:
                                     pytest.get("captureLogs")
                                 )
 
+                            if pytest.get("xfailStatus"):
+                                xfail_status = pytest.get("xfailStatus")
+
+                                if xfail_status.get("xfail"):
+                                    self.config.framework.pytest.xfail_status.set_xfail(
+                                        xfail_status.get("xfail")
+                                    )
+
+                                if xfail_status.get("xpass"):
+                                    self.config.framework.pytest.xfail_status.set_xpass(
+                                        xfail_status.get("xpass")
+                                    )
+
         except Exception as e:
             self.logger.log("Failed to load config from file", "error")
 
@@ -213,6 +226,13 @@ class ConfigManager:
 
                 if key == 'QASE_PYTEST_CAPTURE_LOGS':
                     self.config.framework.pytest.set_capture_logs(value)
+
+                if key == 'QASE_PYTEST_XFAIL_STATUS_XFAIL':
+                    self.config.framework.pytest.xfail_status.set_xfail(value)
+
+                if key == 'QASE_PYTEST_XFAIL_STATUS_XPASS':
+                    self.config.framework.pytest.xfail_status.set_xpass(value)
+
 
         except Exception as e:
             self.logger.log("Failed to load config from env vars {e}", "error")

--- a/qase-python-commons/src/qase/commons/models/config/framework.py
+++ b/qase-python-commons/src/qase/commons/models/config/framework.py
@@ -17,11 +17,28 @@ class Trace(Enum):
     failed = "retain-on-failure"
 
 
+class XFailStatus(BaseModel):
+    xfail: str = None
+    xpass: str = None
+
+    def __init__(self):
+        self.xfail = 'skipped'
+        self.xpass = 'passed'
+
+    def set_xfail(self, value: str):
+        self.xfail = value
+
+    def set_xpass(self, value: str):
+        self.xpass = value
+
+
 class PytestConfig(BaseModel):
     capture_logs: bool = None
+    xfail_status: XFailStatus = None
 
     def __init__(self):
         self.capture_logs = False
+        self.xfail_status = XFailStatus()
 
     def set_capture_logs(self, capture_logs):
         self.capture_logs = QaseUtils.parse_bool(capture_logs)


### PR DESCRIPTION
- Introduced configuration for custom statuses of xfail-marked tests.
- Default statuses: `skipped` for failed tests and `passed` for successful tests.
- Added methods to read values from `qase.config.json` and environment variables:
  - `QASE_PYTEST_XFAIL_STATUS_XFAIL` for failed xfail tests.
  - `QASE_PYTEST_XFAIL_STATUS_XPASS` for successful xfail tests.