### PR TITLE
fix: fix handling of `pytest.xfail` and `skipif` mark

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 5

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,11 @@
+# qase-pytest 6.1.11
+
+## What's new
+
+Fixed issues with using `pytest.xfail` and the `skipif` mark:
+1. Custom statuses did not work when using `pytest.xfail` within the test body.
+2. The status was incorrect when using the `skipif` mark.
+
 # qase-pytest 6.1.10
 
 ## What's new
@@ -6,6 +14,7 @@ The ability to override statuses for tests marked with the `xfail` marker has be
 assigned the `skipped` status, and passed tests are assigned the `passed` status. Custom statuses can be specified by
 providing the slug of the desired status in the configuration. Configuration values can be set via `qase.config.json` or
 environment variables:
+
 - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
 - `QASE_PYTEST_XFAIL_STATUS_XPASS`
 

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.10"
+version = "6.1.11"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]


### PR DESCRIPTION
Resolved the following issues:
	1.	Custom statuses did not work when using `pytest.xfail` within the test body. #321
	2.	The test status was displayed incorrectly when using the `skipif` mark. #320

This pull request includes several changes to the `qase-pytest` plugin, focusing on version updates, bug fixes, and improvements to the handling of test statuses and logging.

### Version Update:

* [`qase-pytest/pyproject.toml`](diffhunk://#diff-eed5955cc5fa2d784b80f72dfcdfc0377506f787ab2c7991c290250c19bb90bfL7-R7): Updated the version from 6.1.10 to 6.1.11.

### Bug Fixes:

* [`qase-pytest/changelog.md`](diffhunk://#diff-609a0b77c1f71e92cd56a2ab7ff5985176f398032295fc4f0bbd9daa415ef9c8R1-R8): Documented fixes for issues with `pytest.xfail` and the `skipif` mark, where custom statuses did not work within the test body and the status was incorrect, respectively.

### Improvements to Test Status Handling:

* [`qase-pytest/src/qase/pytest/plugin.py`](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L144-L195): Refactored the `pytest_runtest_makereport` method to improve the handling of `xfail` statuses and ensure correct status assignment for skipped and failed tests. This includes the addition of a helper method `handle_xfail_status` to determine the correct status based on the `xfail` mark.
* [`qase-pytest/src/qase/pytest/plugin.py`](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L392-R402): Modified the `__is_use_xfail_mark` method to check for the `wasxfail` attribute instead of the `xfail` keyword in the report.

### Logging Enhancements:

* [`qase-pytest/src/qase/pytest/plugin.py`](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L144-L195): Improved log attachment handling by consolidating the logic into a new `attach_logs` method and ensuring logs are attached only when the test call phase is complete.