### PR TITLE
qase-api-client: Update urllib3 to 2.3.0

### DIFF
--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.7"
 dependencies = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3, < 2.3.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-client/requirements.txt
+++ b/qase-api-client/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3, < 2.3.0
 pydantic >= 2
 typing-extensions >= 4.7.1


### PR DESCRIPTION
Hi!
Thank you for your work!

I need to update `urllib3` in my current project, but I can't do that because `qase-api-client` has a frozen version of it `>= 1.25.3, < 2.1.0`.

**Reason of update**: [proxy-authorization in urllib3 request header is not stripped during cross-origin redirects]( https://avd.aquasec.com/nvd/cve-2024-37891)

I updated version in `qase-api-client/pyproject.toml` and in `qase-api-client/requirements.txt` and ran the tests - everything passed


P.S. I haven't found any rules for contributing to the project, so let me know if I've done smth wrong