### PR TITLE
chore: update urllib3 package version

### DIFF
--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "1.1.1"
+version = "1.1.2"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "1.1.0"
+version = "1.1.1"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.7"
 dependencies = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3, < 2.3.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-v2-client/requirements.txt
+++ b/qase-api-v2-client/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3, < 2.3.0
 pydantic >= 2
 typing-extensions >= 4.7.1


### PR DESCRIPTION
This pull request includes several updates to version numbers and dependency constraints for the `qase-api-client` and `qase-api-v2-client` projects. The changes are primarily focused on updating the versions and dependencies to ensure compatibility and stability.

Version updates:
* [`qase-api-client/pyproject.toml`](diffhunk://#diff-b43468612552c57d4eddc2590928a1a185bca47b58e86f9559215984b02ffc1aL7-R7): Updated the version from `1.1.1` to `1.1.2`.
* [`qase-api-v2-client/pyproject.toml`](diffhunk://#diff-4b54856fa80d46bde8bb753440e85ed7a5cdd8101623294194ee85430c4d3f29L7-R7): Updated the version from `1.1.0` to `1.1.1`.

Dependency updates:
* [`qase-api-v2-client/pyproject.toml`](diffhunk://#diff-4b54856fa80d46bde8bb753440e85ed7a5cdd8101623294194ee85430c4d3f29L25-R25): Updated the `urllib3` dependency constraint from `< 2.1.0` to `< 2.3.0`.
* [`qase-api-v2-client/requirements.txt`](diffhunk://#diff-a0e72c14c7487bb3270a218bbe35c4db394c60b557ac6676bb5bf2eba9816044L3-R3): Updated the `urllib3` dependency constraint from `< 2.1.0` to `< 2.3.0`.