### PR TITLE
fix: `author` and `muted` decorators

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.12
+
+## What's new
+
+1. Removed unsupported `tags` decorator as our API does not support working with tags.
+2. Fixed an issue where data was not passed correctly when using `author` and `muted` decorators.
+
 # qase-pytest 6.1.11
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.11"
+version = "6.1.12"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/decorators.py
+++ b/qase-pytest/src/qase/pytest/decorators.py
@@ -153,18 +153,6 @@ class qase:
         return pytest.mark.qase_layer(layer=layer)
 
     @staticmethod
-    def tags(*tags):
-        """
-        >>> @qase.tags("tag1", "tag2")
-        >>> def test_example():
-        >>>     pass
-
-        :param tags: a list of strings with test tags.
-        :return: pytest.mark instance
-        """
-        return pytest.mark.qase_tags(tags=tags)
-
-    @staticmethod
     def ignore():
         """
         >>> @qase.ignore()

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -210,7 +210,6 @@ class QasePytestPlugin:
             signature='',
         )
         self._set_fields(item)
-        self._set_tags(item)
         self._set_author(item)
         self._set_muted(item)
         self._set_testops_id(item)
@@ -294,14 +293,6 @@ class QasePytestPlugin:
             fields = item.get_closest_marker("qase_fields").kwargs.get("fields")
             for name, field in fields:
                 self.runtime.result.add_field(Field(name, field))
-        except:
-            pass
-
-    def _set_tags(self, item) -> None:
-        try:
-            tags = item.get_closest_marker("qase_tags").kwargs.get("tags")
-            for tag in tags:
-                self.runtime.result.add_tag(tag)
         except:
             pass
 

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -307,13 +307,17 @@ class QasePytestPlugin:
 
     def _set_author(self, item) -> None:
         try:
-            self.runtime.result.author = str(item.get_closest_marker("qase_author").kwargs.get("author"))
+            author = str(item.get_closest_marker("qase_author").kwargs.get("author"))
+            if author != "None":
+                self.runtime.result.add_field(Field("author", author))
         except:
             pass
 
     def _set_muted(self, item) -> None:
         try:
-            self.runtime.result.muted = True if item.get_closest_marker("qase_muted").kwargs.get("muted") else False
+            muted = True if item.get_closest_marker("qase_muted") else False
+            if muted:
+                self.runtime.result.add_field(Field("muted", "true"))
         except:
             pass
 


### PR DESCRIPTION
This pull request includes several changes to the `qase-pytest` plugin, primarily focusing on removing unsupported functionality and fixing issues with data handling in decorators. The most important changes include the removal of the `tags` decorator, updates to the version number, and improvements to how data is passed for the `author` and `muted` decorators.

### Removal of unsupported functionality:
* Removed the unsupported `tags` decorator from the `qase-pytest` plugin as the API does not support working with tags. (`qase-pytest/src/qase/pytest/decorators.py`)
* Removed the `_set_tags` method from the plugin as it is no longer needed due to the removal of the `tags` decorator. (`qase-pytest/src/qase/pytest/plugin.py`)

### Fixes and improvements:
* Fixed an issue where data was not passed correctly when using the `author` and `muted` decorators. Now, the `author` and `muted` fields are correctly set if they are present. (`qase-pytest/src/qase/pytest/plugin.py`)

### Version update:
* Updated the version number of the `qase-pytest` plugin from `6.1.11` to `6.1.12` in the `pyproject.toml` file. (`qase-pytest/pyproject.toml`)

### Documentation:
* Updated the `changelog.md` file to reflect the changes in version `6.1.12`, including the removal of the `tags` decorator and the fix for the `author` and `muted` decorators. (`qase-pytest/changelog.md`)