### PR TITLE
fix: handle missing 'video' attribute in pytest plugin

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.13
+
+## What's new
+
+Resolved an issue in the pytest plugin where an AttributeError ('BookingForm' object has no attribute 'video') could
+occur during pytest_runtest_makereport.
+
 # qase-pytest 6.1.12
 
 ## What's new
@@ -10,6 +17,7 @@
 ## What's new
 
 Fixed issues with using `pytest.xfail` and the `skipif` mark:
+
 1. Custom statuses did not work when using `pytest.xfail` within the test body.
 2. The status was incorrect when using the `skipif` mark.
 

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.12"
+version = "6.1.13"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -192,7 +192,7 @@ class QasePytestPlugin:
 
         if hasattr(item, 'funcargs') and 'page' in item.funcargs and call.when == "call":
             page = item.funcargs['page']
-            if page.video:
+            if hasattr(page, 'video'):
                 folder_name = self.__build_folder_name(item)
                 output_dir = self.config.framework.playwright.output_dir
                 base_path = os.path.join(os.getcwd(), output_dir, folder_name)


### PR DESCRIPTION
This pull request includes updates to the `qase-pytest` plugin, addressing a bug fix, version bump, and changelog update. The most important changes are:

Bug Fix:
* [`qase-pytest/src/qase/pytest/plugin.py`](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L195-R195): Resolved an issue where an AttributeError could occur due to the 'video' attribute not being present on the 'page' object by adding a check using `hasattr`.

Version Update:
* [`qase-pytest/pyproject.toml`](diffhunk://#diff-eed5955cc5fa2d784b80f72dfcdfc0377506f787ab2c7991c290250c19bb90bfL7-R7): Updated the version from 6.1.12 to 6.1.13.

Changelog Update:
* [`qase-pytest/changelog.md`](diffhunk://#diff-609a0b77c1f71e92cd56a2ab7ff5985176f398032295fc4f0bbd9daa415ef9c8R1-R7): Added a new entry for version 6.1.13 detailing the resolved AttributeError issue in the pytest plugin.
* [`qase-pytest/changelog.md`](diffhunk://#diff-609a0b77c1f71e92cd56a2ab7ff5985176f398032295fc4f0bbd9daa415ef9c8R20): Fixed formatting for the entry about issues with `pytest.xfail` and `skipif` mark.