### PR TITLE
fix: handle missing 'browser_name' attribute in pytest plugin

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.14
+
+## What's new
+
+Resolved an issue in the pytest plugin where an KeyError ('browser_name') could
+occur during pytest_runtest_makereport.
+
 # qase-pytest 6.1.13
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.13"
+version = "6.1.14"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -384,7 +384,9 @@ class QasePytestPlugin:
         path_parts.append(
             QasePytestPlugin.__sanitize_path_component(item.originalname)
         )
-        path_parts.append(item.funcargs['browser_name'])
+
+        if 'browser_name' in item.funcargs:
+            path_parts.append(item.funcargs['browser_name'])
 
         return "-".join(path_parts)
 


### PR DESCRIPTION
This pull request includes updates to the `qase-pytest` plugin, focusing on resolving an issue and updating the version. The most important changes are as follows:

Bug Fix:
* Resolved a KeyError ('browser_name') that could occur during `pytest_runtest_makereport` in the pytest plugin.

Version Update:
* Updated the version from `6.1.13` to `6.1.14` in the `pyproject.toml` file.

Code Adjustment:
* Modified the `__build_folder_name` method to check for 'browser_name' in `item.funcargs` before appending it to `path_parts`.

#328