### PR TITLE
feat: update logger to write logs to a single file from multiple threads

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.2.5
+
+## What's new
+
+Updated logger to write logs to a single file from multiple threads, ensuring better concurrency handling and readability.  
+
 # qase-python-commons@3.2.4
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.2.4"
+version = "3.2.5"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]


### PR DESCRIPTION
This pull request includes changes to improve the logging functionality in the `qase-python-commons` library, specifically enhancing the concurrency handling and readability of logs. The version number has also been updated to reflect these changes.

Improvements to logging functionality:

* [`qase-python-commons/src/qase/commons/logger.py`](diffhunk://#diff-abba44e6d3cfa2e9999535874f1866b50eecfe8e15ebd23e2f5cb000c4273a90L1-R38): Updated the logger to write logs to a single file from multiple threads by introducing a class-level log file and a threading lock to ensure thread safety.

Version update:

* [`qase-python-commons/pyproject.toml`](diffhunk://#diff-58b0d6680262cbdcbf5891ee16e7c7551e879b6f6d713b15faf7535ef685f655L7-R7): Updated the version number from `3.2.4` to `3.2.5`.

Documentation update:

* [`qase-python-commons/changelog.md`](diffhunk://#diff-2ab54d02d55a31cc42df2dd1e128fa2b5b07755fc55fddb9aa3b6235d837f3b7R1-R6): Added an entry for version `3.2.5` detailing the updated logger functionality.