### PR TITLE
fix: suppress attachment upload failure message when disabled in config

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.1.15
+
+## What's new
+
+Resolved an issue where a failure message for attachment uploads was displayed even when attachments were disabled in
+the configuration.
+
 # qase-pytest 6.1.14
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.14"
+version = "6.1.15"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 import mimetypes
 
 from qase.commons.models import Relation
-from qase.commons.models.config.framework import Trace
+from qase.commons.models.config.framework import Trace, Video
 from qase.commons.models.relation import SuiteData
 from qase.commons.models.result import Result, Field
 from qase.commons.models.attachment import Attachment
@@ -197,8 +197,9 @@ class QasePytestPlugin:
                 output_dir = self.config.framework.playwright.output_dir
                 base_path = os.path.join(os.getcwd(), output_dir, folder_name)
 
-                video_path = os.path.join(base_path, "video.webm")
-                self.add_attachments(video_path)
+                if self.config.framework.playwright.video != Video.off:
+                    video_path = os.path.join(base_path, "video.webm")
+                    self.add_attachments(video_path)
 
                 if self.config.framework.playwright.trace != Trace.off:
                     trace_path = os.path.join(base_path, "trace.zip")


### PR DESCRIPTION
This pull request includes changes to the `qase-pytest` plugin, focusing on version updates, bug fixes, and enhancements to the attachment handling functionality.

### Version Update:
* Updated the version in `pyproject.toml` from 6.1.14 to 6.1.15.

### Bug Fixes:
* Resolved an issue where a failure message for attachment uploads was displayed even when attachments were disabled in the configuration.

### Enhancements:
* Added handling for video attachments in the `handle_xfail_status` method, ensuring videos are attached if the video setting is not turned off.

### Code Imports:
* Updated imports in `plugin.py` to include `Video` from `qase.commons.models.config.framework`.