### PR TITLE
fix: ensure `defect` field is properly applied in result submission

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.2.7
+
+## What's new
+
+Resolved an issue where the defect field in the configuration was ignored during test result submission.
+
 # qase-python-commons@3.2.5
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.2.6"
+version = "3.2.7"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -87,6 +87,7 @@ class ApiV2Client(ApiV1Client):
             param_groups=result.param_groups,
             muted=False,
             message=result.message,
+            defect=self.config.testops.defect,
         )
 
         if result.relations is not None and result.relations.suite is not None and len(


### PR DESCRIPTION
This pull request includes several updates to the `qase-python-commons` library, focusing on fixing a defect field issue and updating the version number. The most important changes are listed below:

### Bug Fixes:
* Resolved an issue where the defect field in the configuration was ignored during test result submission in `qase-python-commons/src/qase/commons/client/api_v2_client.py`.

### Version Update:
* Updated the version number from 3.2.6 to 3.2.7 in `qase-python-commons/pyproject.toml`.

### Documentation:
* Added a new entry for version 3.2.7 in `qase-python-commons/changelog.md` to document the resolved defect field issue.