### PR TITLE
feat: add support for multiple IDs in a single test result

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.3.0
+
+## What's new
+
+Enabled support for assigning multiple IDs to a single test result, allowing better traceability across test cases.
+
 # qase-python-commons@3.2.7
 
 ## What's new
@@ -8,7 +14,8 @@ Resolved an issue where the defect field in the configuration was ignored during
 
 ## What's new
 
-Updated logger to write logs to a single file from multiple threads, ensuring better concurrency handling and readability.  
+Updated logger to write logs to a single file from multiple threads, ensuring better concurrency handling and
+readability.
 
 # qase-python-commons@3.2.4
 
@@ -17,8 +24,8 @@ Updated logger to write logs to a single file from multiple threads, ensuring be
 - Support for custom statuses of xfail-marked tests in pytest.
 - Default statuses: `skipped` (failed xfail) and `passed` (successful xfail).
 - Configuration values can be set via `qase.config.json` or environment variables:
-  - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
-  - `QASE_PYTEST_XFAIL_STATUS_XPASS`
+    - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
+    - `QASE_PYTEST_XFAIL_STATUS_XPASS`
 
 # qase-python-commons@3.2.3
 

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.2.7"
+version = "3.3.0"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -7,7 +7,7 @@ from qase.api_client_v1.configuration import Configuration
 from .. import Logger
 from .base_api_client import BaseApiClient
 from ..exceptions.reporter import ReporterException
-from ..models import Attachment, Result, Step
+from ..models import Attachment, InternalResult, Step
 from ..models.config.framework import Video, Trace
 from ..models.config.qaseconfig import QaseConfig
 from ..models.step import StepType
@@ -134,7 +134,7 @@ class ApiV1Client(BaseApiClient):
         )
         self.logger.log_debug(f"Results for run {run_id} sent successfully")
 
-    def _prepare_result(self, project_code: str, result: Result) -> Dict:
+    def _prepare_result(self, project_code: str, result: InternalResult) -> Dict:
         attached = []
         if result.attachments:
             for attachment in result.attachments:

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -17,7 +17,7 @@ from .api_v1_client import ApiV1Client
 from .. import Logger
 from ..exceptions.reporter import ReporterException
 from ..models.config.framework import Video, Trace
-from ..models import Attachment, Result
+from ..models import Attachment, InternalResult
 from ..models.config.qaseconfig import QaseConfig
 from ..models.step import StepType, Step
 
@@ -53,7 +53,7 @@ class ApiV2Client(ApiV1Client):
                                       create_results_request_v2=CreateResultsRequestV2(results=results_to_send))
         self.logger.log_debug(f"Results for run {run_id} sent successfully")
 
-    def _prepare_result(self, project_code: str, result: Result) -> ResultCreate:
+    def _prepare_result(self, project_code: str, result: InternalResult) -> ResultCreate:
         attached = []
         if result.attachments:
             for attachment in result.attachments:
@@ -85,7 +85,6 @@ class ApiV2Client(ApiV1Client):
             steps_type=ResultStepsType.CLASSIC,
             params=result.params,
             param_groups=result.param_groups,
-            muted=False,
             message=result.message,
             defect=self.config.testops.defect,
         )

--- a/qase-python-commons/src/qase/commons/models/__init__.py
+++ b/qase-python-commons/src/qase/commons/models/__init__.py
@@ -1,4 +1,4 @@
-from .result import Result, Field
+from .result import Result, InternalResult, Field
 from .run import Run
 from .attachment import Attachment
 from .relation import Relation
@@ -12,5 +12,6 @@ __all__ = [
     Relation,
     Step,
     Runtime,
-    Field
+    Field,
+    InternalResult
 ]

--- a/qase-python-commons/src/qase/commons/models/result.py
+++ b/qase-python-commons/src/qase/commons/models/result.py
@@ -1,3 +1,4 @@
+import copy
 import time
 import uuid
 
@@ -70,6 +71,70 @@ class Result(BaseModel):
         self.title: str = title
         self.signature: str = signature
         self.run_id: Optional[str] = None
+        self.testops_id: Optional[List[int]] = None
+        self.execution: Type[Execution] = Execution()
+        self.fields: Dict[Type[Field]] = {}
+        self.attachments: List[Attachment] = []
+        self.steps: List[Type[Step]] = []
+        self.params: Optional[dict] = {}
+        self.param_groups: Optional[List[List[str]]] = []
+        self.author: Optional[str] = None
+        self.relations: Type[Relation] = None
+        self.muted: bool = False
+        self.message: Optional[str] = None
+        QaseUtils.get_host_data()
+
+    def add_message(self, message: str) -> None:
+        self.message = message
+
+    def add_field(self, field: Type[Field]) -> None:
+        self.fields[field.name] = field.value
+
+    def add_steps(self, steps: List[Type[Step]]) -> None:
+        self.steps = QaseUtils().build_tree(steps)
+
+    def add_attachment(self, attachment: Attachment) -> None:
+        self.attachments.append(attachment)
+
+    def add_param(self, key: str, value: str) -> None:
+        self.params[key] = value
+
+    def add_param_groups(self, values: List[str]) -> None:
+        self.param_groups.append(values)
+
+    def set_relation(self, relation: Relation) -> None:
+        self.relations = relation
+
+    def get_status(self) -> Optional[str]:
+        return self.execution.status
+
+    def get_id(self) -> str:
+        return self.id
+
+    def get_title(self) -> str:
+        return self.title
+
+    def get_field(self, name: str) -> Optional[Type[Field]]:
+        if name in self.fields:
+            return self.fields[name]
+        return None
+
+    def get_testops_id(self) -> Optional[List[int]]:
+        return self.testops_id
+
+    def get_duration(self) -> int:
+        return self.execution.duration
+
+    def set_run_id(self, run_id: str) -> None:
+        self.run_id = run_id
+
+
+class InternalResult(BaseModel):
+    def __init__(self, title: str, signature: str) -> None:
+        self.id: str = str(uuid.uuid4())
+        self.title: str = title
+        self.signature: str = signature
+        self.run_id: Optional[str] = None
         self.testops_id: Optional[int] = None
         self.execution: Type[Execution] = Execution()
         self.fields: Dict[Type[Field]] = {}
@@ -126,3 +191,24 @@ class Result(BaseModel):
 
     def set_run_id(self, run_id: str) -> None:
         self.run_id = run_id
+
+    @classmethod
+    def convert_from_result(cls, result: Result, testops_id: Optional[int] = None):
+        int_result = cls(result.title, result.signature)
+
+        int_result.id = result.id
+        int_result.title = result.title
+        int_result.signature = result.signature
+        int_result.run_id = result.run_id
+        int_result.testops_id = testops_id
+        int_result.execution = copy.deepcopy(result.execution)
+        int_result.fields = result.fields
+        int_result.attachments = result.attachments
+        int_result.steps = result.steps
+        int_result.params = result.params
+        int_result.author = result.author
+        int_result.relations = result.relations
+        int_result.muted = result.muted
+        int_result.message = result.message
+
+        return int_result

--- a/qase-python-commons/src/qase/commons/reporters/core.py
+++ b/qase-python-commons/src/qase/commons/reporters/core.py
@@ -1,5 +1,3 @@
-import os
-import json
 import time
 
 from ..config import ConfigManager
@@ -8,7 +6,7 @@ from ..logger import Logger
 from .report import QaseReport
 from .testops import QaseTestOps
 
-from ..models import Result, Attachment, Runtime
+from ..models import InternalResult, Result, Attachment, Runtime
 from ..models.config.qaseconfig import Mode
 from typing import Union, List
 
@@ -81,7 +79,21 @@ class QaseCoreReporter:
             try:
                 ts = time.time()
                 self.logger.log_debug(f"Adding result {result}")
-                self.reporter.add_result(result)
+                ids = result.get_testops_id()
+
+                if ids is None:
+                    int_result = InternalResult.convert_from_result(result)
+                    self.reporter.add_result(int_result)
+                else:
+                    first = True
+                    for testops_id in ids:
+                        int_result = InternalResult.convert_from_result(result, testops_id)
+                        if not first:
+                            int_result.execution.duration = 0
+                        else:
+                            first = False
+                        self.reporter.add_result(int_result)
+
                 self.logger.log_debug(f"Result {result.get_title()} added")
                 self.overhead += time.time() - ts
             except Exception as e:
@@ -180,7 +192,7 @@ class QaseCoreReporter:
                     host=self.config.testops.api.host
                 )
                 self._execution_plan = loader.load(self.config.testops.project,
-                                                  int(self.config.testops.plan.id))
+                                                   int(self.config.testops.plan.id))
         except Exception as e:
             self.logger.log('Failed to load test plan from Qase TestOps', 'info')
             self.logger.log(e, 'error')

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import json
 import re
-from ..models import Result, Run, Attachment
+from ..models import InternalResult, Run, Attachment
 from .. import QaseUtils, Logger
 from ..models.config.connection import Format
 from ..models.config.qaseconfig import QaseConfig
@@ -40,7 +40,7 @@ class QaseReport:
     def complete_worker(self):
         pass
 
-    def add_result(self, result: Result):
+    def add_result(self, result: InternalResult):
         result.set_run_id(self.run_id)
         for attachment in result.attachments:
             self._persist_attachment(attachment)
@@ -91,7 +91,7 @@ class QaseReport:
                     self._persist_attachments_in_steps(step.steps)
 
     # Method saves result to a file
-    def _store_result(self, result: Result):
+    def _store_result(self, result: InternalResult):
         self._store_object(result, self.report_path + "/results/", result.id)
 
     def _check_report_path(self):

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -6,7 +6,7 @@ from typing import List
 from .. import Logger, ReporterException
 from ..client.api_v1_client import ApiV1Client
 from ..client.base_api_client import BaseApiClient
-from ..models import Result
+from ..models import InternalResult
 from ..models.config.qaseconfig import QaseConfig
 
 DEFAULT_BATCH_SIZE = 200
@@ -129,7 +129,7 @@ class QaseTestOps:
         if len(self.results) > 0:
             self._send_results()
 
-    def add_result(self, result: Result) -> None:
+    def add_result(self, result: InternalResult) -> None:
         if result.get_status() == 'failed':
             self.__show_link(result.testops_id, result.title)
         self.results.append(result)


### PR DESCRIPTION
This pull request introduces several important changes to the `qase-python-commons` library, including support for assigning multiple IDs to a single test result, various updates to the logger, and the introduction of a new `InternalResult` model. The changes also involve updating several methods and classes to use the new `InternalResult` model.

### New Features:
* Enabled support for assigning multiple IDs to a single test result, enhancing traceability across test cases.

### Model Updates:
* Introduced a new `InternalResult` model and updated various methods and classes to use this new model instead of the `Result` model. [[1]](diffhunk://#diff-6e6fb740183246d5bb64af672c81a52dcb14e3ee297b002f8314c905c59d6d20L10-R10) [[2]](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3L20-R20) [[3]](diffhunk://#diff-6dd8ebb99ffbd1487d7116e2bc023cb596e0d23a1156e5150bc27bf1b8f305b1L1-R1) [[4]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4R1) [[5]](diffhunk://#diff-65dba806e8d8b28a82037cf0053550f42c54f052ae8142fa8413e3df5fd71702L6-R6) [[6]](diffhunk://#diff-c3ef0354637ba462a6e8bdbb9047cf89b41f44684fb8dafde882443f1835aaa1L9-R9)
* Added methods to the `Result` class for setting and retrieving various attributes, such as `message`, `field`, `steps`, `attachments`, `params`, `param_groups`, `relation`, and `status`.

### Logging and Concurrency:
* Updated logger to write logs to a single file from multiple threads, improving concurrency handling and readability.

### Version Update:
* Updated the version in `pyproject.toml` from `3.2.7` to `3.3.0`.