### PR TITLE
feat: update qase.id() decorator to support multiple test case IDs

### DIFF
--- a/qase-pytest/README.md
+++ b/qase-pytest/README.md
@@ -89,6 +89,10 @@ from qase.pytest import qase
 )
 def test_example_1():
     pass
+
+@qase.id([14, 15])
+def test_example_2():
+    pass
 ```
 
 Each unique number can only be assigned once to the class or function being used.

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,15 @@
+# qase-pytest 6.2.0
+
+## What's new
+
+Updated `qase.id()` decorator to support a list of integers, allowing one test to be linked to multiple test cases.
+
+```python
+@qase.id([2, 3])
+def test_example():
+    pass
+```
+
 # qase-pytest 6.1.15
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.1.15"
+version = "6.2.0"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.2.4",
+    "qase-python-commons~=3.3.0",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/decorators.py
+++ b/qase-pytest/src/qase/pytest/decorators.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 import pytest
 
@@ -13,7 +13,7 @@ class qase:
     """Class with decorators for pytest"""
 
     @staticmethod
-    def id(id):
+    def id(id: Union[int, List[int]]):
         """
         Define a persisent connection to Qase TestOps test case.
 
@@ -21,9 +21,17 @@ class qase:
         >>> def test_example():
         >>>     pass
 
-        :param id: int id of test case
+        >>> @qase.id([2,3])
+        >>> def test_example():
+        >>>     pass
+
+        :param id: int or list of int id of test case
         :return: pytest.mark instance
         """
+
+        if isinstance(id, list) and all(isinstance(item, int) for item in id):
+            return pytest.mark.qase_id(id=','.join(str(i) for i in id))
+
         return pytest.mark.qase_id(id=id)
 
     @staticmethod


### PR DESCRIPTION
This pull request updates the `qase-pytest` plugin to version 6.2.0, introducing support for linking one test to multiple test cases using the `qase.id()` decorator. It also includes several code improvements and dependency updates. Here are the most important changes:

### New Features:
* Updated `qase.id()` decorator to support a list of integers, allowing one test to be linked to multiple test cases. (`qase-pytest/README.md`, `qase-pytest/changelog.md`, `qase-pytest/src/qase/pytest/decorators.py`) [[1]](diffhunk://#diff-8de780d2fae15d9fcb4360bd89edb50e19709e82041322c3ff395afa83338988R92-R95) [[2]](diffhunk://#diff-609a0b77c1f71e92cd56a2ab7ff5985176f398032295fc4f0bbd9daa415ef9c8R1-R12) [[3]](diffhunk://#diff-9ca4d6b108c9a1ff82deecf9ad5c37c4721c7e82642858568de416a2a58b2e2dL16-R34)

### Code Improvements:
* Added a static method `_get_qase_ids` to retrieve Qase IDs from test markers, supporting both single and multiple IDs. (`qase-pytest/src/qase/pytest/plugin.py`)
* Modified `pytest_collection_modifyitems` and `_set_testops_id` methods to handle multiple Qase IDs. (`qase-pytest/src/qase/pytest/plugin.py`) [[1]](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L99-R107) [[2]](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L318-R324)

### Dependency Updates:
* Updated `qase-python-commons` dependency to version `3.3.0` in `pyproject.toml`. (`qase-pytest/pyproject.toml`)

### Version Update:
* Bumped the plugin version to `6.2.0` in `pyproject.toml`. (`qase-pytest/pyproject.toml`)