### PR TITLE
feat: add support for multiple IDs linking a single test to multiple test cases

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,14 @@
+# qase-behave 1.0.2
+
+## What's new
+
+Added support for specifying multiple test case IDs for a single automated test, improving test case association and
+traceability.
+
+```gherkin
+@qase.id:2,3,4
+Scenario: Test with QaseID
+```
 # qase-behave 1.0.1
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.0.1"
+version = "1.0.2"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.2.2",
+    "qase-python-commons~=3.3.0",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -22,7 +22,7 @@ def filter_scenarios(case_ids: List[int], scenarios: List[Scenario]) -> List[Sce
     for scenario in scenarios:
         tags = __parse_tags(scenario.tags)
         if TESTOPS_ID in tags:
-            if int(tags[TESTOPS_ID]) in case_ids:
+            if any(id in case_ids for id in tags[TESTOPS_ID]):
                 executed_scenarios.append(scenario)
 
     return executed_scenarios
@@ -66,7 +66,7 @@ def __parse_tags(tags) -> dict:
 
     for tag in tags:
         if tag.lower().startswith("qase.id"):
-            meta_data[TESTOPS_ID] = int(tag.split(":")[1])
+            meta_data[TESTOPS_ID] = [int(x) for x in (tag.split(":")[1]).split(',')]
             continue
 
         if tag.lower().startswith("qase.fields"):

--- a/qase-behave/tests/test_utils.py
+++ b/qase-behave/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_parse_scenario_with_tags(mock_scenario):
         tags=["qase.id:123", "qase.fields:{\"key\":\"value\"}", "qase.suite:suite1||suite2"]
     )
     result = parse_scenario(scenario)
-    assert result.testops_id == 123
+    assert result.testops_id == [123]
     assert result.fields == {"key": "value"}
     assert len(result.relations.suite.data) == 2
     assert result.relations.suite.data[0].title == "suite1"


### PR DESCRIPTION
This pull request includes updates to the `qase-behave` plugin, adding support for specifying multiple test case IDs for a single automated test, updating dependencies, and making necessary changes to the codebase to support these features.

Improvements and features:

* [`qase-behave/changelog.md`](diffhunk://#diff-bf1ce6331f35e791f4927eab7f3cf0e48d5c99b48459b629dfbdcb3576628613R1-R11): Added a new entry for version 1.0.2, highlighting the support for multiple test case IDs.

Dependency updates:

* [`qase-behave/pyproject.toml`](diffhunk://#diff-931cf7a616c4d6ee3bab9cbbf56462aa986af4d12491ffcb43b5ec50f50ee296L7-R7): Updated the version to 1.0.2 and changed the `qase-python-commons` dependency to version 3.3.0. [[1]](diffhunk://#diff-931cf7a616c4d6ee3bab9cbbf56462aa986af4d12491ffcb43b5ec50f50ee296L7-R7) [[2]](diffhunk://#diff-931cf7a616c4d6ee3bab9cbbf56462aa986af4d12491ffcb43b5ec50f50ee296L32-R32)

Codebase changes:

* [`qase-behave/src/qase/behave/utils.py`](diffhunk://#diff-d5474ed4ebacb117f43644002dff8b46945d0ad89001952434d16d2d9968bbeaL25-R25): Modified the `filter_scenarios` function to check if any of the IDs in the tag are in the case IDs list, and updated the `__parse_tags` function to handle multiple IDs by converting them into a list. [[1]](diffhunk://#diff-d5474ed4ebacb117f43644002dff8b46945d0ad89001952434d16d2d9968bbeaL25-R25) [[2]](diffhunk://#diff-d5474ed4ebacb117f43644002dff8b46945d0ad89001952434d16d2d9968bbeaL69-R69)