### PR TITLE
refactor: restructure pytest_runtest_makereport for improved maintainability

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 6.2.1
+
+## What's new
+
+When specifying a reason in xfail or skip marks, this reason will be added to the result comment.
+
 # qase-pytest 6.2.0
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.2.0"
+version = "6.2.1"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]


### PR DESCRIPTION
This pull request includes several changes to the `qase-pytest` plugin to improve functionality and code readability. The most important changes involve adding new features, refactoring existing code, and updating documentation.

### New Features:
* Updated `changelog.md` to include a new feature that adds the reason specified in xfail or skip marks to the result comment.

### Code Refactoring:
* Refactored `pytest_runtest_makereport` method in `plugin.py` to improve readability and maintainability by breaking down the function into smaller helper methods such as `_process_test_result`, `_handle_failed_test`, `_handle_skipped_test`, `_handle_passed_test`, `_get_xfail_status`, `_set_result_status`, `_attach_logs`, and `_process_playwright_artifacts`.
* Simplified `pytest_sessionfinish` method by using a more concise syntax for checking if a file exists.
* Renamed and refactored the static method `__is_use_xfail_mark` to `__is_xfail_mark` for clarity and added a docstring for better understanding.

### Version Update:
* Updated the version in `pyproject.toml` from `6.2.0` to `6.2.1` to reflect the new changes and improvements.