### PR TITLE
feat: improve start/end time handling for tests and steps, add local time support for test runs

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-python-commons@3.3.1
+
+## What's new
+
+- Implemented local time support for test run creation to improve time tracking.
+- Enhanced handling of start and end times for tests and steps, ensuring greater accuracy in reporting.
+
 # qase-python-commons@3.3.0
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.3.0"
+version = "3.3.1"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Dict, Union
 
 import certifi
@@ -99,7 +100,8 @@ class ApiV1Client(BaseApiClient):
             description=description,
             environment_id=(int(environment_id) if environment_id else None),
             plan_id=(int(plan_id) if plan_id else plan_id),
-            is_autotest=True
+            is_autotest=True,
+            start_time=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         )
         self.logger.log_debug(f"Creating test run with parameters: {kwargs}")
         try:

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -78,6 +78,7 @@ class ApiV2Client(ApiV1Client):
             signature=result.signature,
             testops_id=result.get_testops_id(),
             execution=ResultExecution(status=result.execution.status, duration=result.execution.duration,
+                                      start_time=result.execution.start_time, end_time=result.execution.end_time,
                                       stacktrace=result.execution.stacktrace, thread=result.execution.thread),
             fields=ResultCreateFields.from_dict(result.fields),
             attachments=[attach.hash for attach in attached],
@@ -112,6 +113,8 @@ class ApiV2Client(ApiV1Client):
             prepared_step = {'execution': {}, 'data': {}, 'steps': []}
             prepared_step['execution']['status'] = ResultStepStatus(step.execution.status)
             prepared_step['execution']['duration'] = step.execution.duration
+            prepared_step['execution']['start_time'] = step.execution.start_time
+            prepared_step['execution']['end_time'] = step.execution.end_time
 
             if step.step_type == StepType.TEXT:
                 prepared_step['data']['action'] = step.data.action


### PR DESCRIPTION
This pull request includes several changes to the `qase-python-commons` library to enhance the handling of test run creation and reporting accuracy. The most important changes include implementing local time support, enhancing the handling of start and end times, and updating the version number.

Enhancements to time handling:

* [`qase-python-commons/src/qase/commons/client/api_v1_client.py`](diffhunk://#diff-6e6fb740183246d5bb64af672c81a52dcb14e3ee297b002f8314c905c59d6d20L102-R104): Added local time support for test run creation by including the `start_time` parameter with the current UTC time.
* [`qase-python-commons/src/qase/commons/client/api_v2_client.py`](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3R81): Enhanced the `_prepare_result` and `_prepare_step` methods to include `start_time` and `end_time` parameters, ensuring greater accuracy in reporting. [[1]](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3R81) [[2]](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3R116-R117)

Version update:

* [`qase-python-commons/pyproject.toml`](diffhunk://#diff-58b0d6680262cbdcbf5891ee16e7c7551e879b6f6d713b15faf7535ef685f655L7-R7): Updated the version number from `3.3.0` to `3.3.1`.

Changelog update:

* [`qase-python-commons/changelog.md`](diffhunk://#diff-2ab54d02d55a31cc42df2dd1e128fa2b5b07755fc55fddb9aa3b6235d837f3b7R1-R7): Documented the new features and enhancements in version `3.3.1`.