### PR TITLE
fix: resolve execution.start time validation issue

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,9 @@
+# qase-robotframework 3.3.1
+
+## What's new
+
+Resolved an issue where `execution.start time` could be set incorrectly, leading to validation errors.
+
 # qase-robotframework 3.3.0
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.3.0"
+version = "3.3.1"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -198,6 +198,7 @@ class Listener:
             step.execution.set_status(STATUSES[result.body[i].status])
             step.execution.start_time = result.body[i].start_time.timestamp()
             step.execution.duration = result.body[i].elapsed_time.microseconds
+            step.execution.end_time = result.body[i].end_time.timestamp()
 
             if hasattr(result.body[i], "body"):
                 step.steps = self.__parse_steps(result.body[i])


### PR DESCRIPTION
This pull request includes updates to the `qase-robotframework` project, addressing a bug fix and version increment. The most important changes are detailed below:

Bug Fix:

* [`qase-robotframework/src/qase/robotframework/listener.py`](diffhunk://#diff-bd564381e4cb784a3767fa297740b6a951d3419d0858bc9515b7db2aacef31a8R201): Added the `end_time` attribute to the step execution to ensure the correct setting of execution times.

Version Increment:

* [`qase-robotframework/pyproject.toml`](diffhunk://#diff-0af540c11e659381732acbce538f4f9e5a8b2e35fb82931c0d64bce15809761cL7-R7): Updated the project version from `3.3.0` to `3.3.1`.

Documentation Update:

* [`qase-robotframework/changelog.md`](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R6): Added a new section for version `3.3.1`, detailing the resolved issue with `execution.start_time` validation errors.