### PR TITLE
chore: regenerate API clients based on the latest specification

### DIFF
--- a/qase-api-client/docs/CasesApi.md
+++ b/qase-api-client/docs/CasesApi.md
@@ -452,7 +452,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_case**
-> TestCaseResponse get_case(code, id)
+> TestCaseResponse get_case(code, id, include=include)
 
 Get a specific test case
 
@@ -491,10 +491,11 @@ with qase.api_client_v1.ApiClient(configuration) as api_client:
     api_instance = qase.api_client_v1.CasesApi(api_client)
     code = 'code_example' # str | Code of project, where to search entities.
     id = 56 # int | Identifier.
+    include = 'include_example' # str | A list of entities to include in response separated by comma. Possible values: external_issues.  (optional)
 
     try:
         # Get a specific test case
-        api_response = api_instance.get_case(code, id)
+        api_response = api_instance.get_case(code, id, include=include)
         print("The response of CasesApi->get_case:\n")
         pprint(api_response)
     except Exception as e:
@@ -510,6 +511,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **code** | **str**| Code of project, where to search entities. | 
  **id** | **int**| Identifier. | 
+ **include** | **str**| A list of entities to include in response separated by comma. Possible values: external_issues.  | [optional] 
 
 ### Return type
 

--- a/qase-api-client/docs/QqlTestCase.md
+++ b/qase-api-client/docs/QqlTestCase.md
@@ -32,6 +32,7 @@ Name | Type | Description | Notes
 **author_id** | **int** |  | [optional] 
 **created_at** | **datetime** |  | [optional] 
 **updated_at** | **datetime** |  | [optional] 
+**updated_by** | **int** | Author ID of the last update. | [optional] 
 
 ## Example
 

--- a/qase-api-client/docs/Run.md
+++ b/qase-api-client/docs/Run.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **public** | **bool** |  | [optional] 
 **stats** | [**RunStats**](RunStats.md) |  | [optional] 
 **time_spent** | **int** | Time in ms. | [optional] 
+**elapsed_time** | **int** | Time in ms. | [optional] 
 **environment** | [**RunEnvironment**](RunEnvironment.md) |  | [optional] 
 **milestone** | [**RunMilestone**](RunMilestone.md) |  | [optional] 
 **custom_fields** | [**List[CustomFieldValue]**](CustomFieldValue.md) |  | [optional] 

--- a/qase-api-client/docs/RunQuery.md
+++ b/qase-api-client/docs/RunQuery.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **public** | **bool** |  | [optional] 
 **stats** | [**RunStats**](RunStats.md) |  | [optional] 
 **time_spent** | **int** | Time in ms. | [optional] 
+**elapsed_time** | **int** | Time in ms. | [optional] 
 **environment** | [**RunEnvironment**](RunEnvironment.md) |  | [optional] 
 **milestone** | [**RunMilestone**](RunMilestone.md) |  | [optional] 
 **custom_fields** | [**List[CustomFieldValue]**](CustomFieldValue.md) |  | [optional] 

--- a/qase-api-client/docs/SearchResponseAllOfResultEntities.md
+++ b/qase-api-client/docs/SearchResponseAllOfResultEntities.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **public** | **bool** |  | [optional] 
 **stats** | [**RunStats**](RunStats.md) |  | [optional] 
 **time_spent** | **int** | Time in ms. | [optional] 
+**elapsed_time** | **int** | Time in ms. | [optional] 
 **environment** | [**RunEnvironment**](RunEnvironment.md) |  | [optional] 
 **milestone** | [**RunMilestone**](RunMilestone.md) |  | [optional] 
 **custom_fields** | [**List[CustomFieldValue]**](CustomFieldValue.md) |  | [optional] 
@@ -52,6 +53,7 @@ Name | Type | Description | Notes
 **steps_type** | **str** |  | [optional] 
 **params** | [**TestCaseParams**](TestCaseParams.md) |  | [optional] 
 **author_id** | **int** |  | [optional] 
+**updated_by** | **int** | Author ID of the last update. | [optional] 
 **defect_id** | **int** |  | 
 **actual_result** | **str** |  | [optional] 
 **resolved** | **datetime** |  | [optional] 

--- a/qase-api-client/docs/TestCaseQuery.md
+++ b/qase-api-client/docs/TestCaseQuery.md
@@ -32,6 +32,7 @@ Name | Type | Description | Notes
 **author_id** | **int** |  | [optional] 
 **created_at** | **datetime** |  | [optional] 
 **updated_at** | **datetime** |  | [optional] 
+**updated_by** | **int** | Author ID of the last update. | [optional] 
 
 ## Example
 

--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "1.1.3"
+version = "1.2.0"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-client/src/qase/api_client_v1/api/cases_api.py
+++ b/qase-api-client/src/qase/api_client_v1/api/cases_api.py
@@ -1560,6 +1560,7 @@ class CasesApi:
         self,
         code: Annotated[str, Field(min_length=2, strict=True, max_length=10, description="Code of project, where to search entities.")],
         id: Annotated[StrictInt, Field(description="Identifier.")],
+        include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1581,6 +1582,8 @@ class CasesApi:
         :type code: str
         :param id: Identifier. (required)
         :type id: int
+        :param include: A list of entities to include in response separated by comma. Possible values: external_issues. 
+        :type include: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1606,6 +1609,7 @@ class CasesApi:
         _param = self._get_case_serialize(
             code=code,
             id=id,
+            include=include,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1637,6 +1641,7 @@ class CasesApi:
         self,
         code: Annotated[str, Field(min_length=2, strict=True, max_length=10, description="Code of project, where to search entities.")],
         id: Annotated[StrictInt, Field(description="Identifier.")],
+        include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1658,6 +1663,8 @@ class CasesApi:
         :type code: str
         :param id: Identifier. (required)
         :type id: int
+        :param include: A list of entities to include in response separated by comma. Possible values: external_issues. 
+        :type include: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1683,6 +1690,7 @@ class CasesApi:
         _param = self._get_case_serialize(
             code=code,
             id=id,
+            include=include,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1714,6 +1722,7 @@ class CasesApi:
         self,
         code: Annotated[str, Field(min_length=2, strict=True, max_length=10, description="Code of project, where to search entities.")],
         id: Annotated[StrictInt, Field(description="Identifier.")],
+        include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1735,6 +1744,8 @@ class CasesApi:
         :type code: str
         :param id: Identifier. (required)
         :type id: int
+        :param include: A list of entities to include in response separated by comma. Possible values: external_issues. 
+        :type include: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1760,6 +1771,7 @@ class CasesApi:
         _param = self._get_case_serialize(
             code=code,
             id=id,
+            include=include,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1786,6 +1798,7 @@ class CasesApi:
         self,
         code,
         id,
+        include,
         _request_auth,
         _content_type,
         _headers,
@@ -1810,6 +1823,10 @@ class CasesApi:
         if id is not None:
             _path_params['id'] = id
         # process the query parameters
+        if include is not None:
+            
+            _query_params.append(('include', include))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/qase-api-client/src/qase/api_client_v1/models/qql_test_case.py
+++ b/qase-api-client/src/qase/api_client_v1/models/qql_test_case.py
@@ -60,7 +60,8 @@ class QqlTestCase(BaseModel):
     author_id: Optional[StrictInt] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    __properties: ClassVar[List[str]] = ["id", "test_case_id", "position", "title", "description", "preconditions", "postconditions", "severity", "priority", "type", "layer", "is_flaky", "behavior", "automation", "status", "milestone_id", "suite_id", "custom_fields", "attachments", "steps_type", "steps", "params", "tags", "member_id", "author_id", "created_at", "updated_at"]
+    updated_by: Optional[StrictInt] = Field(default=None, description="Author ID of the last update.")
+    __properties: ClassVar[List[str]] = ["id", "test_case_id", "position", "title", "description", "preconditions", "postconditions", "severity", "priority", "type", "layer", "is_flaky", "behavior", "automation", "status", "milestone_id", "suite_id", "custom_fields", "attachments", "steps_type", "steps", "params", "tags", "member_id", "author_id", "created_at", "updated_at", "updated_by"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -200,7 +201,8 @@ class QqlTestCase(BaseModel):
             "member_id": obj.get("member_id"),
             "author_id": obj.get("author_id"),
             "created_at": obj.get("created_at"),
-            "updated_at": obj.get("updated_at")
+            "updated_at": obj.get("updated_at"),
+            "updated_by": obj.get("updated_by")
         })
         return _obj
 

--- a/qase-api-client/src/qase/api_client_v1/models/run.py
+++ b/qase-api-client/src/qase/api_client_v1/models/run.py
@@ -44,13 +44,14 @@ class Run(BaseModel):
     public: Optional[StrictBool] = None
     stats: Optional[RunStats] = None
     time_spent: Optional[StrictInt] = Field(default=None, description="Time in ms.")
+    elapsed_time: Optional[StrictInt] = Field(default=None, description="Time in ms.")
     environment: Optional[RunEnvironment] = None
     milestone: Optional[RunMilestone] = None
     custom_fields: Optional[List[CustomFieldValue]] = None
     tags: Optional[List[TagValue]] = None
     cases: Optional[List[StrictInt]] = None
     plan_id: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["id", "run_id", "title", "description", "status", "status_text", "start_time", "end_time", "public", "stats", "time_spent", "environment", "milestone", "custom_fields", "tags", "cases", "plan_id"]
+    __properties: ClassVar[List[str]] = ["id", "run_id", "title", "description", "status", "status_text", "start_time", "end_time", "public", "stats", "time_spent", "elapsed_time", "environment", "milestone", "custom_fields", "tags", "cases", "plan_id"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -167,6 +168,7 @@ class Run(BaseModel):
             "public": obj.get("public"),
             "stats": RunStats.from_dict(obj["stats"]) if obj.get("stats") is not None else None,
             "time_spent": obj.get("time_spent"),
+            "elapsed_time": obj.get("elapsed_time"),
             "environment": RunEnvironment.from_dict(obj["environment"]) if obj.get("environment") is not None else None,
             "milestone": RunMilestone.from_dict(obj["milestone"]) if obj.get("milestone") is not None else None,
             "custom_fields": [CustomFieldValue.from_dict(_item) for _item in obj["custom_fields"]] if obj.get("custom_fields") is not None else None,

--- a/qase-api-client/src/qase/api_client_v1/models/run_query.py
+++ b/qase-api-client/src/qase/api_client_v1/models/run_query.py
@@ -44,13 +44,14 @@ class RunQuery(BaseModel):
     public: Optional[StrictBool] = None
     stats: Optional[RunStats] = None
     time_spent: Optional[StrictInt] = Field(default=None, description="Time in ms.")
+    elapsed_time: Optional[StrictInt] = Field(default=None, description="Time in ms.")
     environment: Optional[RunEnvironment] = None
     milestone: Optional[RunMilestone] = None
     custom_fields: Optional[List[CustomFieldValue]] = None
     tags: Optional[List[TagValue]] = None
     cases: Optional[List[StrictInt]] = None
     plan_id: Optional[StrictInt] = None
-    __properties: ClassVar[List[str]] = ["id", "run_id", "title", "description", "status", "status_text", "start_time", "end_time", "public", "stats", "time_spent", "environment", "milestone", "custom_fields", "tags", "cases", "plan_id"]
+    __properties: ClassVar[List[str]] = ["id", "run_id", "title", "description", "status", "status_text", "start_time", "end_time", "public", "stats", "time_spent", "elapsed_time", "environment", "milestone", "custom_fields", "tags", "cases", "plan_id"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -167,6 +168,7 @@ class RunQuery(BaseModel):
             "public": obj.get("public"),
             "stats": RunStats.from_dict(obj["stats"]) if obj.get("stats") is not None else None,
             "time_spent": obj.get("time_spent"),
+            "elapsed_time": obj.get("elapsed_time"),
             "environment": RunEnvironment.from_dict(obj["environment"]) if obj.get("environment") is not None else None,
             "milestone": RunMilestone.from_dict(obj["milestone"]) if obj.get("milestone") is not None else None,
             "custom_fields": [CustomFieldValue.from_dict(_item) for _item in obj["custom_fields"]] if obj.get("custom_fields") is not None else None,

--- a/qase-api-client/src/qase/api_client_v1/models/test_case_query.py
+++ b/qase-api-client/src/qase/api_client_v1/models/test_case_query.py
@@ -60,7 +60,8 @@ class TestCaseQuery(BaseModel):
     author_id: Optional[StrictInt] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    __properties: ClassVar[List[str]] = ["id", "test_case_id", "position", "title", "description", "preconditions", "postconditions", "severity", "priority", "type", "layer", "is_flaky", "behavior", "automation", "status", "milestone_id", "suite_id", "custom_fields", "attachments", "steps_type", "steps", "params", "tags", "member_id", "author_id", "created_at", "updated_at"]
+    updated_by: Optional[StrictInt] = Field(default=None, description="Author ID of the last update.")
+    __properties: ClassVar[List[str]] = ["id", "test_case_id", "position", "title", "description", "preconditions", "postconditions", "severity", "priority", "type", "layer", "is_flaky", "behavior", "automation", "status", "milestone_id", "suite_id", "custom_fields", "attachments", "steps_type", "steps", "params", "tags", "member_id", "author_id", "created_at", "updated_at", "updated_by"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -200,7 +201,8 @@ class TestCaseQuery(BaseModel):
             "member_id": obj.get("member_id"),
             "author_id": obj.get("author_id"),
             "created_at": obj.get("created_at"),
-            "updated_at": obj.get("updated_at")
+            "updated_at": obj.get("updated_at"),
+            "updated_by": obj.get("updated_by")
         })
         return _obj
 

--- a/qase-api-v2-client/docs/ResultCreate.md
+++ b/qase-api-v2-client/docs/ResultCreate.md
@@ -8,7 +8,8 @@ Name | Type | Description | Notes
 **id** | **str** | If passed, used as an idempotency key | [optional] 
 **title** | **str** |  | 
 **signature** | **str** |  | [optional] 
-**testops_id** | **int** |  | [optional] 
+**testops_id** | **int** | ID of the test case. Cannot be specified together with testopd_ids. | [optional] 
+**testops_ids** | **List[int]** | IDs of the test cases. Cannot be specified together with testopd_id. | [optional] 
 **execution** | [**ResultExecution**](ResultExecution.md) |  | 
 **fields** | [**ResultCreateFields**](ResultCreateFields.md) |  | [optional] 
 **attachments** | **List[str]** |  | [optional] 

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "1.1.2"
+version = "1.2.0"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_create.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_create.py
@@ -35,7 +35,8 @@ class ResultCreate(BaseModel):
     id: Optional[StrictStr] = Field(default=None, description="If passed, used as an idempotency key")
     title: StrictStr
     signature: Optional[StrictStr] = None
-    testops_id: Optional[StrictInt] = None
+    testops_id: Optional[StrictInt] = Field(default=None, description="ID of the test case. Cannot be specified together with testopd_ids.")
+    testops_ids: Optional[List[StrictInt]] = Field(default=None, description="IDs of the test cases. Cannot be specified together with testopd_id.")
     execution: ResultExecution
     fields: Optional[ResultCreateFields] = None
     attachments: Optional[List[StrictStr]] = None
@@ -46,7 +47,7 @@ class ResultCreate(BaseModel):
     relations: Optional[ResultRelations] = None
     message: Optional[StrictStr] = None
     defect: Optional[StrictBool] = Field(default=None, description="If true and the result is failed, the defect associated with the result will be created")
-    __properties: ClassVar[List[str]] = ["id", "title", "signature", "testops_id", "execution", "fields", "attachments", "steps", "steps_type", "params", "param_groups", "relations", "message", "defect"]
+    __properties: ClassVar[List[str]] = ["id", "title", "signature", "testops_id", "testops_ids", "execution", "fields", "attachments", "steps", "steps_type", "params", "param_groups", "relations", "message", "defect"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -108,6 +109,11 @@ class ResultCreate(BaseModel):
         if self.testops_id is None and "testops_id" in self.model_fields_set:
             _dict['testops_id'] = None
 
+        # set to None if testops_ids (nullable) is None
+        # and model_fields_set contains the field
+        if self.testops_ids is None and "testops_ids" in self.model_fields_set:
+            _dict['testops_ids'] = None
+
         # set to None if steps_type (nullable) is None
         # and model_fields_set contains the field
         if self.steps_type is None and "steps_type" in self.model_fields_set:
@@ -144,6 +150,7 @@ class ResultCreate(BaseModel):
             "title": obj.get("title"),
             "signature": obj.get("signature"),
             "testops_id": obj.get("testops_id"),
+            "testops_ids": obj.get("testops_ids"),
             "execution": ResultExecution.from_dict(obj["execution"]) if obj.get("execution") is not None else None,
             "fields": ResultCreateFields.from_dict(obj["fields"]) if obj.get("fields") is not None else None,
             "attachments": obj.get("attachments"),


### PR DESCRIPTION
This pull request includes several updates to the `qase-api-client` documentation and codebase, focusing on adding new fields and enhancing the `get_case` method. The most important changes include modifications to support the `include` parameter in the `get_case` method, and the addition of new fields to various models.

Enhancements to `get_case` method:

* [`qase-api-client/docs/CasesApi.md`](diffhunk://#diff-08ccbdcae934f63d6c911ae3e089c24d9cb9f6f6dfba6d8f508e15b07e42dea0L455-R455): Added `include` parameter to the `get_case` method documentation. [[1]](diffhunk://#diff-08ccbdcae934f63d6c911ae3e089c24d9cb9f6f6dfba6d8f508e15b07e42dea0L455-R455) [[2]](diffhunk://#diff-08ccbdcae934f63d6c911ae3e089c24d9cb9f6f6dfba6d8f508e15b07e42dea0R494-R498) [[3]](diffhunk://#diff-08ccbdcae934f63d6c911ae3e089c24d9cb9f6f6dfba6d8f508e15b07e42dea0R514)
* [`qase-api-client/src/qase/api_client_v1/api/cases_api.py`](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1563): Updated `get_case` and related methods to include the `include` parameter for specifying entities to include in the response. [[1]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1563) [[2]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1585-R1586) [[3]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1612) [[4]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1644) [[5]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1666-R1667) [[6]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1693) [[7]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1725) [[8]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1747-R1748) [[9]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1774) [[10]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1801) [[11]](diffhunk://#diff-58ca06aeef581156972355e8cb497bb22f9a30fd306d36eb29c9998a6838e03cR1826-R1829)

Addition of new fields to models:

* [`qase-api-client/docs/QqlTestCase.md`](diffhunk://#diff-cf80ae72088af700374e4b5591cc1c9708e6d5f5715d2367a97441714cb82d6bR35): Added `updated_by` field to document the author ID of the last update.
* `qase-api-client/docs/Run.md`, `qase-api-client/docs/RunQuery.md`, `qase-api-client/docs/SearchResponseAllOfResultEntities.md`: Added `elapsed_time` field to document the elapsed time in milliseconds. [[1]](diffhunk://#diff-5e2601ec643767687bb458dface92744a18585d783f3bc5f719ac378e3721c8aR19) [[2]](diffhunk://#diff-ed719b033cdadba6b868fd70f5b068135b776c2ed475b569c7fa9d0f4f60a47cR19) [[3]](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R19)
* [`qase-api-client/docs/SearchResponseAllOfResultEntities.md`](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R56): Added `updated_by` field to document the author ID of the last update.
* `qase-api-client/src/qase/api_client_v1/models/qql_test_case.py`, `qase-api-client/src/qase/api_client_v1/models/test_case_query.py`: Added `updated_by` field to the models. [[1]](diffhunk://#diff-f1f280055733707170309ecc0cf77ef83de570f1585e176aebee5a7fb99458daL63-R64) [[2]](diffhunk://#diff-f1f280055733707170309ecc0cf77ef83de570f1585e176aebee5a7fb99458daL203-R205) [[3]](diffhunk://#diff-0ad8abcf378b60fcd9c6429de57f13bde4763a122370ca412478c1a437eea616L63-R64)
* `qase-api-client/src/qase/api_client_v1/models/run.py`, `qase-api-client/src/qase/api_client_v1/models/run_query.py`: Added `elapsed_time` field to the models. [[1]](diffhunk://#diff-5db21f1b5ae2e0133c700d04f75fc544f5dd48ffabca705e3c93b6e2f5934292R47-R54) [[2]](diffhunk://#diff-5db21f1b5ae2e0133c700d04f75fc544f5dd48ffabca705e3c93b6e2f5934292R171) [[3]](diffhunk://#diff-de92493eb99130353c905f89a76d21aab2cf4bd1022b591a491fe644f122b629R47-R54) [[4]](diffhunk://#diff-de92493eb99130353c905f89a76d21aab2cf4bd1022b591a491fe644f122b629R171)

Version update:

* [`qase-api-client/pyproject.toml`](diffhunk://#diff-b43468612552c57d4eddc2590928a1a185bca47b58e86f9559215984b02ffc1aL7-R7): Updated the version from `1.1.3` to `1.2.0`.