### PR TITLE
feat: update supported API client versions and enforce API v2 usage

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,11 @@
+# qase-python-commons@3.4.0
+
+## What's new
+
+- Updated API clients to the latest supported versions.
+- Improved logic for handling multiple QaseID values in test results.
+- Removed `useV2` configuration option. The reporter now always uses API v2 for sending results.
+
 # qase-python-commons@3.3.2
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.3.2"
+version = "3.4.0"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -30,8 +30,8 @@ requires-python = ">=3.7"
 dependencies = [
     "certifi>=2024.2.2",
     "attrs>=23.2.0",
-    "qase-api-client~=1.1.1",
-    "qase-api-v2-client~=1.1.0",
+    "qase-api-client~=1.2.0",
+    "qase-api-v2-client~=1.2.0",
     "more_itertools"
 ]
 

--- a/qase-python-commons/requirements.txt
+++ b/qase-python-commons/requirements.txt
@@ -1,6 +1,6 @@
 attrs==23.2.0
 certifi>=2024.2.2
 more-itertools==9.1.0
-pip~=24.0
-qase-api-client~=1.0.1
-qase-api-v2-client~=1.0.0
+pip~=25.0
+qase-api-client~=1.2.0
+qase-api-v2-client~=1.2.0

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -17,7 +17,7 @@ from .api_v1_client import ApiV1Client
 from .. import Logger
 from ..exceptions.reporter import ReporterException
 from ..models.config.framework import Video, Trace
-from ..models import Attachment, InternalResult
+from ..models import Attachment, Result
 from ..models.config.qaseconfig import QaseConfig
 from ..models.step import StepType, Step
 
@@ -53,7 +53,7 @@ class ApiV2Client(ApiV1Client):
                                       create_results_request_v2=CreateResultsRequestV2(results=results_to_send))
         self.logger.log_debug(f"Results for run {run_id} sent successfully")
 
-    def _prepare_result(self, project_code: str, result: InternalResult) -> ResultCreate:
+    def _prepare_result(self, project_code: str, result: Result) -> ResultCreate:
         attached = []
         if result.attachments:
             for attachment in result.attachments:
@@ -76,7 +76,7 @@ class ApiV2Client(ApiV1Client):
         result_model_v2 = ResultCreate(
             title=result.get_title(),
             signature=result.signature,
-            testops_id=result.get_testops_id(),
+            testops_ids=result.get_testops_ids(),
             execution=ResultExecution(status=result.execution.status, duration=result.execution.duration,
                                       start_time=result.execution.start_time, end_time=result.execution.end_time,
                                       stacktrace=result.execution.stacktrace, thread=result.execution.thread),

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -83,11 +83,6 @@ class ConfigManager:
                                 testops.get("defect")
                             )
 
-                        if testops.get("useV2"):
-                            self.config.testops.set_use_v2(
-                                testops.get("useV2")
-                            )
-
                         if testops.get("plan"):
                             plan = testops.get("plan")
 

--- a/qase-python-commons/src/qase/commons/models/__init__.py
+++ b/qase-python-commons/src/qase/commons/models/__init__.py
@@ -1,4 +1,4 @@
-from .result import Result, InternalResult, Field
+from .result import Result, Field
 from .run import Run
 from .attachment import Attachment
 from .relation import Relation
@@ -12,6 +12,5 @@ __all__ = [
     Relation,
     Step,
     Runtime,
-    Field,
-    InternalResult
+    Field
 ]

--- a/qase-python-commons/src/qase/commons/models/config/testops.py
+++ b/qase-python-commons/src/qase/commons/models/config/testops.py
@@ -20,13 +20,9 @@ class TestopsConfig(BaseModel):
         self.batch = BatchConfig()
         self.plan = PlanConfig()
         self.defect = False
-        self.use_v2 = True
 
     def set_project(self, project: str):
         self.project = project
 
     def set_defect(self, defect):
         self.defect = QaseUtils.parse_bool(defect)
-
-    def set_use_v2(self, use_v2):
-        self.use_v2 = QaseUtils.parse_bool(use_v2)

--- a/qase-python-commons/src/qase/commons/models/result.py
+++ b/qase-python-commons/src/qase/commons/models/result.py
@@ -1,4 +1,3 @@
-import copy
 import time
 import uuid
 
@@ -71,7 +70,7 @@ class Result(BaseModel):
         self.title: str = title
         self.signature: str = signature
         self.run_id: Optional[str] = None
-        self.testops_id: Optional[List[int]] = None
+        self.testops_ids: Optional[List[int]] = None
         self.execution: Type[Execution] = Execution()
         self.fields: Dict[Type[Field]] = {}
         self.attachments: List[Attachment] = []
@@ -119,96 +118,11 @@ class Result(BaseModel):
             return self.fields[name]
         return None
 
-    def get_testops_id(self) -> Optional[List[int]]:
-        return self.testops_id
+    def get_testops_ids(self) -> Optional[List[int]]:
+        return self.testops_ids
 
     def get_duration(self) -> int:
         return self.execution.duration
 
     def set_run_id(self, run_id: str) -> None:
         self.run_id = run_id
-
-
-class InternalResult(BaseModel):
-    def __init__(self, title: str, signature: str) -> None:
-        self.id: str = str(uuid.uuid4())
-        self.title: str = title
-        self.signature: str = signature
-        self.run_id: Optional[str] = None
-        self.testops_id: Optional[int] = None
-        self.execution: Type[Execution] = Execution()
-        self.fields: Dict[Type[Field]] = {}
-        self.attachments: List[Attachment] = []
-        self.steps: List[Type[Step]] = []
-        self.params: Optional[dict] = {}
-        self.param_groups: Optional[List[List[str]]] = []
-        self.author: Optional[str] = None
-        self.relations: Type[Relation] = None
-        self.muted: bool = False
-        self.message: Optional[str] = None
-        QaseUtils.get_host_data()
-
-    def add_message(self, message: str) -> None:
-        self.message = message
-
-    def add_field(self, field: Type[Field]) -> None:
-        self.fields[field.name] = field.value
-
-    def add_steps(self, steps: List[Type[Step]]) -> None:
-        self.steps = QaseUtils().build_tree(steps)
-
-    def add_attachment(self, attachment: Attachment) -> None:
-        self.attachments.append(attachment)
-
-    def add_param(self, key: str, value: str) -> None:
-        self.params[key] = value
-
-    def add_param_groups(self, values: List[str]) -> None:
-        self.param_groups.append(values)
-
-    def set_relation(self, relation: Relation) -> None:
-        self.relations = relation
-
-    def get_status(self) -> Optional[str]:
-        return self.execution.status
-
-    def get_id(self) -> str:
-        return self.id
-
-    def get_title(self) -> str:
-        return self.title
-
-    def get_field(self, name: str) -> Optional[Type[Field]]:
-        if name in self.fields:
-            return self.fields[name]
-        return None
-
-    def get_testops_id(self) -> Optional[int]:
-        return self.testops_id
-
-    def get_duration(self) -> int:
-        return self.execution.duration
-
-    def set_run_id(self, run_id: str) -> None:
-        self.run_id = run_id
-
-    @classmethod
-    def convert_from_result(cls, result: Result, testops_id: Optional[int] = None):
-        int_result = cls(result.title, result.signature)
-
-        int_result.id = result.id
-        int_result.title = result.title
-        int_result.signature = result.signature
-        int_result.run_id = result.run_id
-        int_result.testops_id = testops_id
-        int_result.execution = copy.deepcopy(result.execution)
-        int_result.fields = result.fields
-        int_result.attachments = result.attachments
-        int_result.steps = result.steps
-        int_result.params = result.params
-        int_result.author = result.author
-        int_result.relations = result.relations
-        int_result.muted = result.muted
-        int_result.message = result.message
-
-        return int_result

--- a/qase-python-commons/src/qase/commons/reporters/core.py
+++ b/qase-python-commons/src/qase/commons/reporters/core.py
@@ -6,7 +6,7 @@ from ..logger import Logger
 from .report import QaseReport
 from .testops import QaseTestOps
 
-from ..models import InternalResult, Result, Attachment, Runtime
+from ..models import Result, Attachment, Runtime
 from ..models.config.qaseconfig import Mode
 from typing import Union, List
 
@@ -84,20 +84,8 @@ class QaseCoreReporter:
             try:
                 ts = time.time()
                 self.logger.log_debug(f"Adding result {result}")
-                ids = result.get_testops_id()
 
-                if ids is None:
-                    int_result = InternalResult.convert_from_result(result)
-                    self.reporter.add_result(int_result)
-                else:
-                    first = True
-                    for testops_id in ids:
-                        int_result = InternalResult.convert_from_result(result, testops_id)
-                        if not first:
-                            int_result.execution.duration = 0
-                        else:
-                            first = False
-                        self.reporter.add_result(int_result)
+                self.reporter.add_result(result)
 
                 self.logger.log_debug(f"Result {result.get_title()} added")
                 self.overhead += time.time() - ts

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import json
 import re
-from ..models import InternalResult, Run, Attachment
+from ..models import Result, Run, Attachment
 from .. import QaseUtils, Logger
 from ..models.config.connection import Format
 from ..models.config.qaseconfig import QaseConfig
@@ -40,7 +40,7 @@ class QaseReport:
     def complete_worker(self):
         pass
 
-    def add_result(self, result: InternalResult):
+    def add_result(self, result: Result):
         result.set_run_id(self.run_id)
         for attachment in result.attachments:
             self._persist_attachment(attachment)
@@ -91,7 +91,7 @@ class QaseReport:
                     self._persist_attachments_in_steps(step.steps)
 
     # Method saves result to a file
-    def _store_result(self, result: InternalResult):
+    def _store_result(self, result: Result):
         self._store_object(result, self.report_path + "/results/", result.id)
 
     def _check_report_path(self):

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -146,8 +146,7 @@ class QaseTestOps:
     def __prepare_link(self, ids: Union[None, List[int]], title: str):
         link = f"{self.__baseUrl}/run/{self.project_code}/dashboard/{self.run_id}?source=logs&status=%5B2%5D&search="
         if ids is not None and len(ids) > 0:
-            return f"{link}{ids[0]}`"
-
+            return f"{link}{ids[0]}"
         return f"{link}{urllib.parse.quote_plus(title)}"
 
     @staticmethod


### PR DESCRIPTION
This pull request to `qase-python-commons` includes updates to the API clients, improvements in handling multiple QaseID values, and removal of the `useV2` configuration option. Additionally, it simplifies the codebase by removing the `InternalResult` class and related methods.

### API Client Updates:
* Updated API clients to the latest supported versions in `pyproject.toml` and `requirements.txt`. [[1]](diffhunk://#diff-58b0d6680262cbdcbf5891ee16e7c7551e879b6f6d713b15faf7535ef685f655L33-R34) [[2]](diffhunk://#diff-f78310afcec4b84c932d966874710dee9e5b22cedbfbda0724e9f6ca09b1393eL4-R6)
* Removed the `useV2` configuration option, making API v2 the default for sending results. [[1]](diffhunk://#diff-2ab54d02d55a31cc42df2dd1e128fa2b5b07755fc55fddb9aa3b6235d837f3b7R1-R8) Ff979c4fL17R17, [[2]](diffhunk://#diff-8f771301108c4cb775b7fd97e9ad565aa02a0a4fcd658b0597edba13861810a3L23-L32)

### Codebase Simplification:
* Removed the `InternalResult` class and all related methods from various files, including `api_v1_client.py`, `api_v2_client.py`, `models/__init__.py`, `models/result.py`, `reporters/core.py`, and `reporters/report.py`. [[1]](diffhunk://#diff-6e6fb740183246d5bb64af672c81a52dcb14e3ee297b002f8314c905c59d6d20L126-L292) [[2]](diffhunk://#diff-6e6fb740183246d5bb64af672c81a52dcb14e3ee297b002f8314c905c59d6d20R135-R137) [[3]](diffhunk://#diff-6d1d3c1fb9c7f62ce3fefb241b625182e5dc2adc3b319a8861fe944f76c9da81L9-R9) [[4]](diffhunk://#diff-6d1d3c1fb9c7f62ce3fefb241b625182e5dc2adc3b319a8861fe944f76c9da81L87-R88) [[5]](diffhunk://#diff-65dba806e8d8b28a82037cf0053550f42c54f052ae8142fa8413e3df5fd71702L6-R6) [[6]](diffhunk://#diff-65dba806e8d8b28a82037cf0053550f42c54f052ae8142fa8413e3df5fd71702L43-R43) [[7]](diffhunk://#diff-65dba806e8d8b28a82037cf0053550f42c54f052ae8142fa8413e3df5fd71702L94-R94) [[8]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4L1) [[9]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4L74-R73) [[10]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4L122-L214) [[11]](diffhunk://#diff-6dd8ebb99ffbd1487d7116e2bc023cb596e0d23a1156e5150bc27bf1b8f305b1L1-R1) [[12]](diffhunk://#diff-6dd8ebb99ffbd1487d7116e2bc023cb596e0d23a1156e5150bc27bf1b8f305b1L15-R15)

### Version Update:
* Bumped the version from `3.3.2` to `3.4.0` in `pyproject.toml`.

### Miscellaneous:
* Improved logic for handling multiple QaseID values in test results.
* Added a placeholder method in `api_v1_client.py` to raise an error when `send_results` is called, directing users to use `ApiV2Client` instead.