### PR TITLE
feat: update supported core package version and enforce API v2 usage

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,11 @@
+# qase-pytest 6.3.0
+
+## What's new
+
+- Updated core package to the latest supported versions.
+- Improved logic for handling multiple QaseID values in test results.
+- Removed `useV2` configuration option. The reporter now always uses API v2 for sending results.
+
 # qase-pytest 6.2.2
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.2.2"
+version = "6.3.0"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.3.2",
+    "qase-python-commons~=3.4.0",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/requirements.txt
+++ b/qase-pytest/requirements.txt
@@ -1,4 +1,4 @@
 attrs==23.2.0
 pytest>=8.0.0
 filelock~=3.13.1
-qase-python-commons~=3.1.4
+qase-python-commons~=3.4.0

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -272,7 +272,7 @@ class QasePytestPlugin:
         self._set_fields(item)
         self._set_author(item)
         self._set_muted(item)
-        self._set_testops_id(item)
+        self._set_testops_ids(item)
         self._set_params(item)
         self._set_suite(item)
         self._set_relations(item)
@@ -332,8 +332,8 @@ class QasePytestPlugin:
 
     def _get_signature(self, item):
         self.runtime.result.signature = item.nodeid.replace("/", "::")
-        if self.runtime.result.testops_id:
-            self.runtime.result.signature += f"::{self.runtime.result.testops_id}"
+        if self.runtime.result.testops_ids:
+            self.runtime.result.signature += f"::{'-'.join(map(str,self.runtime.result.testops_ids))}"
         for key, val in self.runtime.result.params.items():
             self.runtime.result.signature += f"::{{{key}:{val}}}"
 
@@ -372,9 +372,9 @@ class QasePytestPlugin:
         except:
             pass
 
-    def _set_testops_id(self, item) -> None:
+    def _set_testops_ids(self, item) -> None:
         try:
-            self.runtime.result.testops_id = QasePytestPlugin._get_qase_ids(item)
+            self.runtime.result.testops_ids = QasePytestPlugin._get_qase_ids(item)
         except:
             pass
 


### PR DESCRIPTION
This pull request includes updates to the `qase-pytest` package, focusing on upgrading dependencies, improving the handling of multiple QaseID values, and removing deprecated configuration options. The key changes are summarized below:

### Dependency Updates:
* Updated `qase-python-commons` dependency to version 3.4.0 in both `pyproject.toml` and `requirements.txt` files. [[1]](diffhunk://#diff-eed5955cc5fa2d784b80f72dfcdfc0377506f787ab2c7991c290250c19bb90bfL32-R32) [[2]](diffhunk://#diff-0c5c14f5d8f34f07929c43c3648a171864ec6456aff2972073a9d9ca45b10847L4-R4)

### Feature Improvements:
* Improved logic for handling multiple QaseID values in test results by updating methods to use `testops_ids` instead of `testops_id` in `plugin.py`. [[1]](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L275-R275) [[2]](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L335-R336) [[3]](diffhunk://#diff-ffa84803e3f2ac6e41e1d504fe2c44d5daec81ae30fd9dd901921a50f7984969L375-R377)

### Configuration Changes:
* Removed the `useV2` configuration option from the reporter, enforcing the use of API v2 for sending results.

### Documentation:
* Updated the changelog to reflect the new version 6.3.0 and the changes included in this release.

### Version Bump:
* Bumped the version number from 6.2.2 to 6.3.0 in `pyproject.toml`.