### PR TITLE
feat: update supported core package version and enforce API v2 usage

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,11 @@
+# qase-robotframework 3.4.0
+
+## What's new
+
+- Updated core package to the latest supported versions.
+- Improved logic for handling multiple QaseID values in test results.
+- Removed `useV2` configuration option. The reporter now always uses API v2 for sending results.
+
 # qase-robotframework 3.3.2
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.3.2"
+version = "3.4.0"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -17,7 +17,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.3.2",
+    "qase-python-commons~=3.4.0",
     "filelock~=3.12.2",
 ]
 

--- a/qase-robotframework/requirements.txt
+++ b/qase-robotframework/requirements.txt
@@ -1,3 +1,2 @@
-qase-python-commons~=3.1.3
-
+qase-python-commons~=3.4.0
 robotframework~=7.1

--- a/qase-robotframework/src/qase/robotframework/filter.py
+++ b/qase-robotframework/src/qase/robotframework/filter.py
@@ -14,8 +14,8 @@ class Filter(SuiteVisitor):
     def _is_included(self, test):
         test_metadata = TagParser.parse_tags(test.tags)
 
-        if test_metadata.qase_id:
-            return test_metadata.qase_id in self.tests
+        if test_metadata.qase_ids:
+            return any(qase_id in self.tests for qase_id in test_metadata.qase_ids)
 
         return False
 

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -92,8 +92,8 @@ class Listener:
             logger.info("Test '%s' is ignored", test.name)
             return
 
-        if test_metadata.qase_id:
-            self.runtime.result.testops_id = test_metadata.qase_id
+        if test_metadata.qase_ids:
+            self.runtime.result.testops_ids = test_metadata.qase_ids
 
         self.runtime.result.execution.complete()
         self.runtime.result.execution.set_status(STATUSES[result.status])
@@ -126,8 +126,8 @@ class Listener:
             signature = "::".join(
                 suite.lower().replace(" ", "_") for suite in suites) + f"::{test.name.lower().replace(' ', '_')}"
 
-            if self.runtime.result.testops_id:
-                signature += f"::{self.runtime.result.testops_id}"
+            if self.runtime.result.testops_ids:
+                signature += f"::{'-'.join(map(str, self.runtime.result.testops_ids))}"
 
             self.runtime.result.signature = signature
 

--- a/qase-robotframework/src/qase/robotframework/models.py
+++ b/qase-robotframework/src/qase/robotframework/models.py
@@ -88,13 +88,13 @@ class EndKeywordModel(TypedDict):
 
 
 class TestMetadata:
-    qase_id: Union[List[int], None]
+    qase_ids: Union[List[int], None]
     ignore: bool
     fields: dict
     params: list[str]
 
     def __init__(self) -> None:
-        self.qase_id = []
+        self.qase_ids = []
         self.ignore = False
         self.fields = {}
         self.params = []

--- a/qase-robotframework/src/qase/robotframework/tag_parser.py
+++ b/qase-robotframework/src/qase/robotframework/tag_parser.py
@@ -13,7 +13,9 @@ class TagParser:
         metadata = TestMetadata()
         for tag in tags:
             if tag.lower().startswith("q-"):
-                metadata.qase_id.append(TagParser.__extract_ids(tag))
+                qase_id = TagParser.__extract_ids(tag)
+                if qase_id is not None:
+                    metadata.qase_ids.append(qase_id)
 
             if tag.lower() == "qase.ignore":
                 metadata.ignore = True


### PR DESCRIPTION
This pull request for `qase-robotframework` includes updates to the core package, improvements to test result handling, and several code refactors. The most important changes are summarized below:

### Core Package Updates:
* Updated core package dependencies to the latest supported versions. (`qase-robotframework/changelog.md`, `qase-robotframework/pyproject.toml`, `qase-robotframework/requirements.txt`) [[1]](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R8) [[2]](diffhunk://#diff-0af540c11e659381732acbce538f4f9e5a8b2e35fb82931c0d64bce15809761cL7-R7) [[3]](diffhunk://#diff-0af540c11e659381732acbce538f4f9e5a8b2e35fb82931c0d64bce15809761cL20-R20) [[4]](diffhunk://#diff-bacf55f07cfd4267056c9c662c920cb4065fa7a9ff146b4ed8d33f1c8d009bc0L1-R1)

### Test Result Handling:
* Improved logic for handling multiple QaseID values in test results. (`qase-robotframework/changelog.md`, `qase-robotframework/src/qase/robotframework/filter.py`, `qase-robotframework/src/qase/robotframework/listener.py`, `qase-robotframework/src/qase/robotframework/models.py`, `qase-robotframework/src/qase/robotframework/tag_parser.py`) [[1]](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R8) [[2]](diffhunk://#diff-be9789ac6bc32b2f85da5b538cd29e5d74a71341f96844e80771dc1fbdd524b4L17-R18) [[3]](diffhunk://#diff-bd564381e4cb784a3767fa297740b6a951d3419d0858bc9515b7db2aacef31a8L95-R96) [[4]](diffhunk://#diff-bd564381e4cb784a3767fa297740b6a951d3419d0858bc9515b7db2aacef31a8L129-R130) [[5]](diffhunk://#diff-61423b4ca46d99fb2c42295ace2587b0b7ef54d785422dd271d5f82be239556fL91-R97) [[6]](diffhunk://#diff-abbbb83282dd8bde93c3941cdf723d589b3734b3b3ded18ea5b7961c3e2932b5L16-R16)

### Configuration Changes:
* Removed `useV2` configuration option. The reporter now always uses API v2 for sending results. (`qase-robotframework/changelog.md`)