### PR TITLE
feat: update supported core package version and enforce API v2 usage

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,11 @@
+# qase-behave 1.1.0
+
+## What's new
+
+- Updated core package to the latest supported versions.
+- Improved logic for handling multiple QaseID values in test results.
+- Removed `useV2` configuration option. The reporter now always uses API v2 for sending results.
+
 # qase-behave 1.0.3
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.0.3"
+version = "1.1.0"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.3.2",
+    "qase-python-commons~=3.4.0",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/requirements.txt
+++ b/qase-behave/requirements.txt
@@ -1,3 +1,3 @@
 attrs==23.2.0
 behave>=1.2.6
-qase-python-commons~=3.2.2
+qase-python-commons~=3.4.0

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -11,7 +11,7 @@ from qase.commons.models.step import StepType, StepGherkinData, Step as QaseStep
 SUITE = "suite"
 IGNORE = "ignore"
 FIELDS = "fields"
-TESTOPS_ID = "testops_id"
+TESTOPS_ID = "testops_ids"
 
 
 def filter_scenarios(case_ids: List[int], scenarios: List[Scenario]) -> List[Scenario]:
@@ -22,7 +22,7 @@ def filter_scenarios(case_ids: List[int], scenarios: List[Scenario]) -> List[Sce
     for scenario in scenarios:
         tags = __parse_tags(scenario.tags)
         if TESTOPS_ID in tags:
-            if any(id in case_ids for id in tags[TESTOPS_ID]):
+            if any(qase_id in case_ids for qase_id in tags[TESTOPS_ID]):
                 executed_scenarios.append(scenario)
 
     return executed_scenarios
@@ -33,7 +33,7 @@ def parse_scenario(scenario: Scenario) -> Result:
 
     result = Result(scenario.name, scenario.name)
 
-    result.testops_id = tags.get(TESTOPS_ID, None)
+    result.testops_ids = tags.get(TESTOPS_ID, None)
     result.fields = tags.get(FIELDS, {})
     result.ignore = tags.get(IGNORE, False)
 
@@ -102,5 +102,7 @@ def parse_step(step: Step) -> QaseStep:
     )
 
     model.execution.set_status(step.status.name)
+    model.execution.duration = int(step.duration * 1000)
+    model.execution.end_time = model.execution.start_time + int(step.duration * 1000)
 
     return model

--- a/qase-behave/tests/test_utils.py
+++ b/qase-behave/tests/test_utils.py
@@ -44,7 +44,7 @@ def test_parse_scenario_with_tags(mock_scenario):
         tags=["qase.id:123", "qase.fields:{\"key\":\"value\"}", "qase.suite:suite1||suite2"]
     )
     result = parse_scenario(scenario)
-    assert result.testops_id == [123]
+    assert result.testops_ids == [123]
     assert result.fields == {"key": "value"}
     assert len(result.relations.suite.data) == 2
     assert result.relations.suite.data[0].title == "suite1"
@@ -53,7 +53,7 @@ def test_parse_scenario_with_tags(mock_scenario):
 def test_parse_scenario_without_tags(mock_scenario):
     scenario = mock_scenario(tags=[])
     result = parse_scenario(scenario)
-    assert result.testops_id is None
+    assert result.testops_ids is None
     assert result.fields == {}
     assert len(result.relations.suite.data) == 3
 


### PR DESCRIPTION
This pull request includes several updates and improvements to the `qase-behave` package, focusing on upgrading dependencies, enhancing functionality, and removing outdated configuration options.

### Dependency Updates:
* Updated `qase-python-commons` dependency to version `3.4.0` in `pyproject.toml` and `requirements.txt` files. [[1]](diffhunk://#diff-931cf7a616c4d6ee3bab9cbbf56462aa986af4d12491ffcb43b5ec50f50ee296L32-R32) [[2]](diffhunk://#diff-065776369d86ec2626070e286c137f56320a3e9f9d87fa202c9330f8fe538f7bL3-R3)

### Functional Improvements:
* Improved logic for handling multiple QaseID values in test results by changing `TESTOPS_ID` to `TESTOPS_IDS` in `utils.py`. [[1]](diffhunk://#diff-d5474ed4ebacb117f43644002dff8b46945d0ad89001952434d16d2d9968bbeaL14-R14) [[2]](diffhunk://#diff-d5474ed4ebacb117f43644002dff8b46945d0ad89001952434d16d2d9968bbeaL36-R36)
* Added step duration and end time to the `parse_step` function in `utils.py`.

### Configuration Changes:
* Removed `useV2` configuration option; the reporter now always uses API v2 for sending results.

### Version Bump:
* Updated the version of the package to `1.1.0` in `pyproject.toml`.