### PR TITLE
feat: update supported core package version and enforce API v2 usage

### DIFF
--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,11 @@
+# qase-tavern 1.1.0
+
+## What's new
+
+- Updated core package to the latest supported versions.
+- Improved logic for handling multiple QaseID values in test results.
+- Removed `useV2` configuration option. The reporter now always uses API v2 for sending results.
+
 # qase-tavern 1.0.3
 
 ## What's new

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "1.0.3"
+version = "1.1.0"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.3.2",
+    "qase-python-commons~=3.4.0",
     "pytest>=7,<7.3",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-tavern/requirements.txt
+++ b/qase-tavern/requirements.txt
@@ -1,4 +1,4 @@
 attrs==23.2.0
 pytest>=7,<7.3
 filelock~=3.13.1
-qase-python-commons~=3.2.0
+qase-python-commons~=3.4.0

--- a/qase-tavern/src/qase/tavern/plugin.py
+++ b/qase-tavern/src/qase/tavern/plugin.py
@@ -76,19 +76,17 @@ class QasePytestPlugin:
         self.runtime.clear()
 
     def start_pytest_item(self, item):
-        qase_id, title = self.extract_qase_id(self._get_title(item))
+        qase_ids, title = self.extract_qase_ids(self._get_title(item))
         self.runtime.result = Result(
             title=title,
             signature='',
         )
-        if qase_id:
-            self.runtime.result.testops_id = qase_id
+        if qase_ids:
+            self.runtime.result.testops_ids = qase_ids
 
         self._set_relations(item)
         self._set_steps(item)
         self._get_signature(item)
-
-        # self._set_testops_id(item)
 
     @staticmethod
     def _get_title(item):
@@ -130,13 +128,13 @@ class QasePytestPlugin:
 
     def _get_signature(self, item):
         self.runtime.result.signature = item.nodeid.replace("/", "::")
-        if self.runtime.result.testops_id:
-            self.runtime.result.signature += f"::{self.runtime.result.testops_id}"
+        if self.runtime.result.testops_ids:
+            self.runtime.result.signature += f"::{'-'.join(map(str,self.runtime.result.testops_ids))}"
         for key, val in self.runtime.result.params.items():
             self.runtime.result.signature += f"::{{{key}:{val}}}"
 
     @staticmethod
-    def extract_qase_id(text) -> Tuple[List[int], str]:
+    def extract_qase_ids(text) -> Tuple[List[int], str]:
         if not isinstance(text, str):
             raise ValueError(f"Expected a string, but got {type(text).__name__}: {repr(text)}")
 

--- a/qase-tavern/tests/test_extractor.py
+++ b/qase-tavern/tests/test_extractor.py
@@ -3,53 +3,53 @@ from qase.tavern.plugin import QasePytestPlugin
 
 def test_extract_qase_id_with_valid_id():
     text = "QaseID=123 Some text"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [123]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [123]
     assert remaining_text == "Some text"
 
 def test_extract_multiple_qase_id_with_valid_id():
     text = "QaseID=123,321 Some text"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [123,321]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [123,321]
     assert remaining_text == "Some text"
 
 def test_extract_qase_id_with_valid_id_lowercase():
     text = "qaseid=456 More text"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [456]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [456]
     assert remaining_text == "More text"
 
 
 def test_extract_qase_id_with_no_qaseid():
     text = "No QaseID here"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == []
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == []
     assert remaining_text == text
 
 
 def test_extract_qase_id_with_spaces():
     text = "   QaseID= 321   Text with spaces   "
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [321]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [321]
     assert remaining_text == "Text with spaces"
 
 
 def test_extract_qase_id_with_only_qaseid():
     text = "QaseID=999"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [999]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [999]
     assert remaining_text == ""
 
 
 def test_extract_qase_id_with_special_characters():
     text = "Some text QaseID=123!@#$"
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == [123]
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == [123]
     assert remaining_text == "Some text !@#$"
 
 
 def test_extract_qase_id_with_empty_string():
     text = ""
-    qase_id, remaining_text = QasePytestPlugin.extract_qase_id(text)
-    assert qase_id == []
+    qase_ids, remaining_text = QasePytestPlugin.extract_qase_ids(text)
+    assert qase_ids == []
     assert remaining_text == ""


### PR DESCRIPTION
This pull request includes several updates to the `qase-tavern` package, focusing on version updates, dependency changes, and improvements to the handling of QaseID values in test results.

### Version and Dependency Updates:

* Updated the `qase-tavern` package version to 1.1.0 and updated dependencies in `pyproject.toml` and `requirements.txt` to use `qase-python-commons` version 3.4.0. [[1]](diffhunk://#diff-3926f435e408e1c646bfa711cb34cdbfe0c6a73f733e424512ec80a01895237aL7-R7) [[2]](diffhunk://#diff-3926f435e408e1c646bfa711cb34cdbfe0c6a73f733e424512ec80a01895237aL32-R32) [[3]](diffhunk://#diff-11106ee609a0ac711b089cb6e36b9f93504cda82f55a4fabaf4c1d3cc08d2398L4-R4)

### Improvements to QaseID Handling:

* Modified the logic to handle multiple QaseID values in test results by updating methods in `plugin.py` to use `extract_qase_ids` instead of `extract_qase_id`. [[1]](diffhunk://#diff-5cccb0e287a9097db929222dcf5ca263f4eadf2f5c4f678600ae83cee77c66a5L79-L92) [[2]](diffhunk://#diff-5cccb0e287a9097db929222dcf5ca263f4eadf2f5c4f678600ae83cee77c66a5L133-R137)
* Updated test cases in `test_extractor.py` to reflect changes in QaseID handling by using `extract_qase_ids`.

### Changelog Update:

* Added a new entry for version 1.1.0 in the `changelog.md` file, detailing the core package update, improved QaseID handling, and removal of the `useV2` configuration option.