### PR TITLE
fix: correctly handle steps with IF/ELSE sections

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,10 @@
+# qase-robotframework 3.4.1
+
+## What's new
+
+Fixed an issue with handling steps that contain IF/ELSE sections. Conditional logic is now properly parsed and
+represented in test cases.
+
 # qase-robotframework 3.4.0
 
 ## What's new
@@ -10,8 +17,8 @@
 
 ## What's new
 
-- Logging of host system details to improve debugging and traceability.  
-- Output of installed packages in logs for better environment visibility. 
+- Logging of host system details to improve debugging and traceability.
+- Output of installed packages in logs for better environment visibility.
 
 # qase-robotframework 3.3.1
 

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.4.0"
+version = "3.4.1"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -217,6 +217,7 @@ class Listener:
                     data=StepGherkinData(keyword=result_step.body[i].type, name=result_step.body[i].type, line=0)
                 )
                 step.execution.start_time = None
+                step.execution.end_time = None
                 child_steps = self.__parse_steps(result_step.body[i])
 
                 if all(s.execution.status == "skipped" for s in child_steps):


### PR DESCRIPTION
This pull request updates the `qase-robotframework` plugin to version 3.4.1, addressing a bug in handling conditional logic within test steps and ensuring proper parsing. Below are the most important changes:

### Bug Fixes and Functional Improvements:
* Fixed an issue where steps containing IF/ELSE conditional logic were not properly parsed and represented in test cases. This ensures accurate handling of conditional structures. (`qase-robotframework/changelog.md`, `qase-robotframework/src/qase/robotframework/listener.py`) [[1]](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R7) [[2]](diffhunk://#diff-bd564381e4cb784a3767fa297740b6a951d3419d0858bc9515b7db2aacef31a8R220)

### Version Update:
* Updated the version of the plugin from `3.4.0` to `3.4.1` in `pyproject.toml` to reflect the new release. (`qase-robotframework/pyproject.toml`)