### PR TITLE
fix: correct enum serialization in models

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.4.1
+
+## What's new
+
+Fixed an issue with enum serialization in models
+
 # qase-python-commons@3.4.0
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.4.0"
+version = "3.4.1"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -125,18 +125,18 @@ class ApiV2Client(ApiV1Client):
                 prepared_step['data']['action'] = step.data.request_method + " " + step.data.request_url
 
                 if step.data.request_body:
-                    step.attachments.append(
+                    step.add_attachment(
                         Attachment(file_name='request_body.txt', content=step.data.request_body, mime_type='text/plain',
                                    temporary=True))
                 if step.data.request_headers:
-                    step.attachments.append(
+                    step.add_attachment(
                         Attachment(file_name='request_headers.txt', content=step.data.request_headers,
                                    mime_type='text/plain', temporary=True))
                 if step.data.response_body:
-                    step.attachments.append(Attachment(file_name='response_body.txt', content=step.data.response_body,
-                                                       mime_type='text/plain', temporary=True))
+                    step.add_attachment(Attachment(file_name='response_body.txt', content=step.data.response_body,
+                                                   mime_type='text/plain', temporary=True))
                 if step.data.response_headers:
-                    step.attachments.append(
+                    step.add_attachment(
                         Attachment(file_name='response_headers.txt', content=step.data.response_headers,
                                    mime_type='text/plain', temporary=True))
 
@@ -149,9 +149,9 @@ class ApiV2Client(ApiV1Client):
             if step.step_type == StepType.SLEEP:
                 prepared_step['data']['action'] = f"Sleep for {step.data.duration} seconds"
 
-            if step.attachments:
+            if step.execution.attachments:
                 uploaded_attachments = []
-                for file in step.attachments:
+                for file in step.execution.attachments:
                     attach_id = self._upload_attachment(project_code, file)
                     if attach_id:
                         uploaded_attachments.extend(attach_id)

--- a/qase-python-commons/src/qase/commons/logger.py
+++ b/qase-python-commons/src/qase/commons/logger.py
@@ -24,7 +24,12 @@ class Logger:
     def log(self, message: str, level: str = 'info'):
         time_str = self._get_timestamp("%H:%M:%S")
         log = f"[Qase][{time_str}][{level}] {message}\n"
-        print(log)
+
+        try:
+            print(log, end='')
+        except (OSError, IOError):
+            pass
+
         if self.debug:
             with self.lock:
                 with open(Logger._log_file, 'a', encoding='utf-8') as f:

--- a/qase-python-commons/src/qase/commons/models/basemodel.py
+++ b/qase-python-commons/src/qase/commons/models/basemodel.py
@@ -1,7 +1,16 @@
 import json
 
+from enum import Enum
+
 
 class BaseModel:
-    def __str__(self) -> str:
-        return json.dumps(self, default=lambda o: o.__dict__ if hasattr(o, '__dict__') else str(o), indent=4,
-                          sort_keys=True)
+    def __str__(self, enum_as_name=False) -> str:
+        def serialize(o):
+            if isinstance(o, Enum):
+                return o.name if enum_as_name else o.value
+            elif hasattr(o, '__dict__'):
+                return o.__dict__
+            else:
+                return str(o)
+
+        return json.dumps(self, default=serialize, indent=4, sort_keys=True)

--- a/qase-python-commons/src/qase/commons/models/result.py
+++ b/qase-python-commons/src/qase/commons/models/result.py
@@ -69,7 +69,6 @@ class Result(BaseModel):
         self.id: str = str(uuid.uuid4())
         self.title: str = title
         self.signature: str = signature
-        self.run_id: Optional[str] = None
         self.testops_ids: Optional[List[int]] = None
         self.execution: Type[Execution] = Execution()
         self.fields: Dict[Type[Field]] = {}
@@ -77,11 +76,9 @@ class Result(BaseModel):
         self.steps: List[Type[Step]] = []
         self.params: Optional[dict] = {}
         self.param_groups: Optional[List[List[str]]] = []
-        self.author: Optional[str] = None
         self.relations: Type[Relation] = None
         self.muted: bool = False
         self.message: Optional[str] = None
-        QaseUtils.get_host_data()
 
     def add_message(self, message: str) -> None:
         self.message = message
@@ -123,6 +120,3 @@ class Result(BaseModel):
 
     def get_duration(self) -> int:
         return self.execution.duration
-
-    def set_run_id(self, run_id: str) -> None:
-        self.run_id = run_id

--- a/qase-python-commons/src/qase/commons/models/run.py
+++ b/qase-python-commons/src/qase/commons/models/run.py
@@ -1,5 +1,3 @@
-import json
-
 from typing import Optional, List
 
 from .basemodel import BaseModel
@@ -71,6 +69,7 @@ class Run(BaseModel):
             "duration": result["execution"]["duration"],
             "thread": result["execution"]["thread"]
         }
+        self._extract_path_from_relations(result)
         self.results.append(compact_result)
         self.execution.track(result)
         self.stats.track(result)
@@ -79,3 +78,16 @@ class Run(BaseModel):
 
     def add_host_data(self, host_data: dict):
         self.host_data = host_data
+
+    def _extract_path_from_relations(self, relations_dict):
+
+        titles = []
+        if "relations" in relations_dict and "suite" in relations_dict["relations"]:
+            if "data" in relations_dict["relations"]["suite"]:
+                data_list = relations_dict["relations"]["suite"]["data"]
+                titles = [item["title"] for item in data_list if "title" in item]
+
+        path = "/".join(titles)
+
+        if path and path not in self.suites:
+            self.suites.append(path)

--- a/qase-python-commons/src/qase/commons/models/step.py
+++ b/qase-python-commons/src/qase/commons/models/step.py
@@ -20,6 +20,7 @@ class StepTextData(BaseModel):
     def __init__(self, action: str, expected_result: Optional[str] = None):
         self.action = action
         self.expected_result = expected_result
+        self.input_data = None
 
 
 class StepAssertData(BaseModel):
@@ -78,6 +79,7 @@ class StepExecution(BaseModel):
         self.status = status
         self.end_time = end_time
         self.duration = duration
+        self.attachments = []
 
     def set_status(self, status: Optional[str]):
         if status in ['passed', 'failed', 'skipped', 'blocked', 'untested']:
@@ -88,6 +90,9 @@ class StepExecution(BaseModel):
     def complete(self):
         self.end_time = time.time()
         self.duration = int((self.end_time - self.start_time) * 1000)
+
+    def add_attachment(self, attachment: Attachment):
+        self.attachments.append(attachment)
 
 
 class Step(BaseModel):
@@ -107,7 +112,6 @@ class Step(BaseModel):
         self.data = data
         self.parent_id = parent_id
         self.execution = StepExecution()
-        self.attachments = []
         self.steps = []
 
     def set_parent_id(self, parent_id: Optional[str]):
@@ -132,4 +136,4 @@ class Step(BaseModel):
         self.steps = steps
 
     def add_attachment(self, attachment: Attachment):
-        self.attachments.append(attachment)
+        self.execution.add_attachment(attachment)

--- a/qase-python-commons/src/qase/commons/reporters/report.py
+++ b/qase-python-commons/src/qase/commons/reporters/report.py
@@ -41,7 +41,6 @@ class QaseReport:
         pass
 
     def add_result(self, result: Result):
-        result.set_run_id(self.run_id)
         for attachment in result.attachments:
             self._persist_attachment(attachment)
 
@@ -84,8 +83,8 @@ class QaseReport:
 
     def _persist_attachments_in_steps(self, steps: list):
         for step in steps:
-            if step.attachments:
-                for attachment in step.attachments:
+            if step.execution.attachments:
+                for attachment in step.execution.attachments:
                     self._persist_attachment(attachment)
                 if step.steps:
                     self._persist_attachments_in_steps(step.steps)


### PR DESCRIPTION
This pull request introduces several updates to the `qase-python-commons` library, focusing on bug fixes, enhancements to attachment handling, and code cleanup. The most notable changes include fixing enum serialization, refactoring attachment handling to improve encapsulation, and removing unused fields and methods from models.

### Bug Fixes:
* Fixed an issue with enum serialization in models by updating the `__str__` method in `BaseModel` to handle enums properly, allowing serialization as either names or values. (`qase-python-commons/src/qase/commons/models/basemodel.py`)

### Enhancements to Attachment Handling:
* Replaced the `attachments` list in `Step` with a new `add_attachment` method in `StepExecution` to encapsulate attachment logic. (`qase-python-commons/src/qase/commons/models/step.py`) [[1]](diffhunk://#diff-f3d25ab128db3272b99e7f9c6de7f0e160f80b2dbfdc1b425599a67df30fead8R82) [[2]](diffhunk://#diff-f3d25ab128db3272b99e7f9c6de7f0e160f80b2dbfdc1b425599a67df30fead8R94-R96) [[3]](diffhunk://#diff-f3d25ab128db3272b99e7f9c6de7f0e160f80b2dbfdc1b425599a67df30fead8L135-R139)
* Updated `_prepare_step` in `ApiV2Client` to use the new `add_attachment` method and adjusted logic to reference `execution.attachments` instead of `attachments`. (`qase-python-commons/src/qase/commons/client/api_v2_client.py`) [[1]](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3L128-R139) [[2]](diffhunk://#diff-7eed9fb9f5e094348bd96d459bf5a020a640a196e9b931b0a1f9f2aa163729d3L152-R154)
* Refactored `_persist_attachments_in_steps` in `Report` to align with the new attachment structure. (`qase-python-commons/src/qase/commons/reporters/report.py`)

### Code Cleanup:
* Removed unused fields (`run_id`, `author`) and methods (`set_run_id`) from the `Result` model to streamline the code. (`qase-python-commons/src/qase/commons/models/result.py`) [[1]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4L72-L84) [[2]](diffhunk://#diff-d98b3072c89c3944c00bbae5644c0a2e2f1153cd6240a19f741f5a0abd69e1a4L126-L128)
* Eliminated an unnecessary `import` statement in `Run` and added a private `_extract_path_from_relations` method for extracting suite paths from relations. (`qase-python-commons/src/qase/commons/models/run.py`) [[1]](diffhunk://#diff-083aa6ad4a318b2f217938ea05509a06209e2c933ed1804b5416f0ccbdffee8fL1-L2) [[2]](diffhunk://#diff-083aa6ad4a318b2f217938ea05509a06209e2c933ed1804b5416f0ccbdffee8fR72) [[3]](diffhunk://#diff-083aa6ad4a318b2f217938ea05509a06209e2c933ed1804b5416f0ccbdffee8fR81-R93)

### Logging Improvements:
* Modified the `Logger` to handle potential I/O errors gracefully when printing log messages. (`qase-python-commons/src/qase/commons/logger.py`)

### Version Update:
* Bumped the library version to `3.4.1` and updated the changelog to reflect the enum serialization fix. (`qase-python-commons/pyproject.toml`, `qase-python-commons/changelog.md`) [[1]](diffhunk://#diff-58b0d6680262cbdcbf5891ee16e7c7551e879b6f6d713b15faf7535ef685f655L7-R7) [[2]](diffhunk://#diff-2ab54d02d55a31cc42df2dd1e128fa2b5b07755fc55fddb9aa3b6235d837f3b7R1-R6)