### PR TITLE
fix(config): correct parsing of boolean values from file config

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.4.2
+
+## What's new
+
+Fixed an issue with parsing boolean values from file-based configuration.
+
 # qase-python-commons@3.4.1
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.4.1"
+version = "3.4.2"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -53,7 +53,7 @@ class ConfigManager:
                     if config.get("profilers"):
                         self.config.set_profilers(config.get("profilers"))
 
-                    if config.get("debug"):
+                    if config.get("debug") is not None:
                         self.config.set_debug(
                             config.get("debug")
                         )
@@ -78,7 +78,7 @@ class ConfigManager:
                         if testops.get("project"):
                             self.config.testops.set_project(testops.get("project"))
 
-                        if testops.get("defect"):
+                        if testops.get("defect") is not None:
                             self.config.testops.set_defect(
                                 testops.get("defect")
                             )
@@ -101,7 +101,7 @@ class ConfigManager:
                             if run.get("description"):
                                 self.config.testops.run.set_description(run.get("description"))
 
-                            if run.get("complete"):
+                            if run.get("complete") is not None:
                                 self.config.testops.run.set_complete(
                                     run.get("complete")
                                 )
@@ -135,7 +135,7 @@ class ConfigManager:
                         if framework.get("pytest"):
                             pytest = framework.get("pytest")
 
-                            if pytest.get("captureLogs"):
+                            if pytest.get("captureLogs") is not None:
                                 self.config.framework.pytest.set_capture_logs(
                                     pytest.get("captureLogs")
                                 )


### PR DESCRIPTION
This pull request introduces a patch update to the `qase-python-commons` library, addressing a bug in configuration parsing and ensuring better handling of boolean values. The most significant changes include a version bump, a fix for boolean parsing logic, and an update to the changelog.

### Bug Fixes and Improvements:

* Updated boolean parsing logic in the `__load_file_config` method of `qase-python-commons/src/qase/commons/config.py` to explicitly check for `None` before setting configuration values. This ensures boolean values like `False` are correctly handled. [[1]](diffhunk://#diff-3a957fb2d34893ebfcb8667117cd10158f298623ca67984c98705d676d90fe90L56-R56) [[2]](diffhunk://#diff-3a957fb2d34893ebfcb8667117cd10158f298623ca67984c98705d676d90fe90L81-R81) [[3]](diffhunk://#diff-3a957fb2d34893ebfcb8667117cd10158f298623ca67984c98705d676d90fe90L104-R104) [[4]](diffhunk://#diff-3a957fb2d34893ebfcb8667117cd10158f298623ca67984c98705d676d90fe90L138-R138)

### Versioning and Documentation:

* Updated the version in `qase-python-commons/pyproject.toml` from `3.4.1` to `3.4.2` to reflect the changes in this patch release.
* Added a new entry in `qase-python-commons/changelog.md` for version `3.4.2`, documenting the fix for parsing boolean values in file-based configuration.