### PR TITLE
fix: correct handling of conditional steps execution

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,9 @@
+# qase-robotframework 3.4.2
+
+## What's new
+
+Fixed an issue with handling steps that include conditional execution logic, ensuring correct structure and reporting.
+
 # qase-robotframework 3.4.1
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.4.1"
+version = "3.4.2"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]


### PR DESCRIPTION
This pull request introduces a bug fix and refactors the step parsing logic in the `qase-robotframework` project. The changes aim to resolve issues with conditional execution steps and improve the maintainability of the codebase. Below are the key updates:

### Bug Fix:
* **Changelog Update**: Documented the fix for handling steps with conditional execution logic to ensure proper structure and reporting in version `3.4.2`. (`qase-robotframework/changelog.md`, [qase-robotframework/changelog.mdR1-R6](diffhunk://#diff-3c7f9e6c68fc7a12c5576f8891cdfb49a04fec41f9fda008afa6575d18a18fcbR1-R6))

### Code Refactoring:
* **Improved Step Parsing Logic**: Refactored the `__parse_steps` method in `qase/robotframework/listener.py` to:
  - Use a cleaner loop structure by iterating directly over `result_step.body`.
  - Introduce helper methods `_create_gherkin_step_with_type`, `_create_gherkin_step_from_name`, and `_set_step_status_based_on_children` for better modularity and readability.
  - Ensure that execution start and end times are consistently set to `None` for all steps. (`qase-robotframework/src/qase/robotframework/listener.py`, [qase-robotframework/src/qase/robotframework/listener.pyL212-R266](diffhunk://#diff-bd564381e4cb784a3767fa297740b6a951d3419d0858bc9515b7db2aacef31a8L212-R266))