### PR TITLE
chore: update version and enhance status descriptions

### DIFF
--- a/qase-api-client/docs/TestStepResult.md
+++ b/qase-api-client/docs/TestStepResult.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**status** | **int** |  | [optional] 
+**status** | **int** | 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress | [optional] 
 **position** | **int** |  | [optional] 
 **attachments** | [**List[Attachment]**](Attachment.md) |  | [optional] 
 **steps** | **List[object]** | Nested steps results will be here. The same structure is used for them for them. | [optional] 

--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "1.2.0"
+version = "1.2.1"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-client/src/qase/api_client_v1/models/test_step_result.py
+++ b/qase-api-client/src/qase/api_client_v1/models/test_step_result.py
@@ -28,7 +28,7 @@ class TestStepResult(BaseModel):
     """
     TestStepResult
     """ # noqa: E501
-    status: Optional[StrictInt] = None
+    status: Optional[StrictInt] = Field(default=None, description="1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress")
     position: Optional[StrictInt] = None
     attachments: Optional[List[Attachment]] = None
     steps: Optional[List[Dict[str, Any]]] = Field(default=None, description="Nested steps results will be here. The same structure is used for them for them.")

--- a/qase-api-client/src/qase/api_client_v1/models/test_step_result_create.py
+++ b/qase-api-client/src/qase/api_client_v1/models/test_step_result_create.py
@@ -40,8 +40,8 @@ class TestStepResultCreate(BaseModel):
     @field_validator('status')
     def status_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['passed', 'failed', 'blocked']):
-            raise ValueError("must be one of enum values ('passed', 'failed', 'blocked')")
+        if value not in set(['passed', 'failed', 'blocked', 'in_progress']):
+            raise ValueError("must be one of enum values ('passed', 'failed', 'blocked', 'in_progress')")
         return value
 
     model_config = ConfigDict(

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "1.2.0"
+version = "1.2.1"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_step_status.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_step_status.py
@@ -31,6 +31,7 @@ class ResultStepStatus(str, Enum):
     FAILED = 'failed'
     BLOCKED = 'blocked'
     SKIPPED = 'skipped'
+    IN_PROGRESS = 'in_progress'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:


### PR DESCRIPTION
- Bumped version to 1.2.1 for both qase-api-client and qase-api-v2-client.
- Updated status descriptions in documentation and models to include 'in_progress'.
- Adjusted validation logic to accommodate the new status value.