### PR TITLE
feat: support for specifying test parameters using the `qase.param`

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,20 @@
+# qase-pytest 6.3.1
+
+## What's new
+
+Added support specifing test parameters using `qase.param` method inside the test body.
+
+```python
+def test_example():
+    qase.param("foo", "bar")
+    qase.param("baz", "qux")
+    pass
+
+def test_example(param1: str):
+    qase.param("param1", param1)
+    pass    
+```
+
 # qase-pytest 6.3.0
 
 ## What's new
@@ -11,7 +28,7 @@
 ## What's new
 
 - Logging of host system details to improve debugging and traceability.  
-- Output of installed packages in logs for better environment visibility. 
+- Output of installed packages in logs for better environment visibility.
 
 # qase-pytest 6.2.1
 

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.0"
+version = "6.3.1"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.4.0",
+    "qase-python-commons~=3.4.3",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/decorators.py
+++ b/qase-pytest/src/qase/pytest/decorators.py
@@ -205,6 +205,23 @@ class qase:
             pass
 
     @staticmethod
+    def param(name: str, value: str):
+        """
+        Add a parameter to the current test.
+
+        `name` and `value` are strings.
+
+        >>>
+        ... qase.param("param_name", "param_value")
+        """
+        try:
+            plugin = QasePytestPluginSingleton.get_instance()
+            plugin.add_param(name=name, value=value)
+        except Exception:
+            print("Failed to add parameter")
+            pass
+
+    @staticmethod
     @contextdecorator
     def step(title, expected=None):
         """

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -86,11 +86,11 @@ class QasePytestPlugin:
                     if len(mark.args) != 0:
                         param_name, values = mark.args
                         if ',' in param_name:
-                            grouped_params.append(param_name.split(','))
+                            grouped_params.append([item.strip() for item in param_name.split(',')])
                     else:
                         param_name = mark.kwargs.get('argnames')
                         if ',' in param_name:
-                            grouped_params.append(param_name.split(','))
+                            grouped_params.append([item.strip() for item in param_name.split(',')])
 
             # Attach the captured params to the test item
             item._grouped_params = grouped_params
@@ -307,6 +307,14 @@ class QasePytestPlugin:
             attachment = Attachment(file_name=filename, content=content, mime_type=mime, file_path=file_path)
             self.runtime.add_attachment(attachment)
 
+    def add_param(self, name: str, value: str):
+        """
+        Add a parameter to the current test result.
+        """
+        if not self.runtime.result:
+            return
+        self.runtime.result.add_param(name, value)
+
     def load_run_from_lock(self):
         if QasePytestPlugin.meta_run_file.exists():
             with open(QasePytestPlugin.meta_run_file, "r") as lock_file:
@@ -333,7 +341,7 @@ class QasePytestPlugin:
     def _get_signature(self, item):
         self.runtime.result.signature = item.nodeid.replace("/", "::")
         if self.runtime.result.testops_ids:
-            self.runtime.result.signature += f"::{'-'.join(map(str,self.runtime.result.testops_ids))}"
+            self.runtime.result.signature += f"::{'-'.join(map(str, self.runtime.result.testops_ids))}"
         for key, val in self.runtime.result.params.items():
             self.runtime.result.signature += f"::{{{key}:{val}}}"
 


### PR DESCRIPTION
- Added support for specifying test parameters using the `qase.param` method within test bodies.
- Updated version to 6.3.1 in pyproject.toml.
- Enhanced parameter handling in the plugin for better test result management.