### PR TITLE
fix:  pytest.skip usage inside a step body

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@3.4.4
+
+## What's new
+
+Fixed an issue with the usage of the `pytest.skip` method iside a step body.
+
 # qase-python-commons@3.4.3
 
 ## What's new
@@ -29,7 +35,7 @@ Fixed an issue with enum serialization in models
 ## What's new
 
 - Logging of host system details to improve debugging and traceability.  
-- Output of installed packages in logs for better environment visibility. 
+- Output of installed packages in logs for better environment visibility.
 
 # qase-python-commons@3.3.1
 
@@ -64,8 +70,8 @@ readability.
 - Support for custom statuses of xfail-marked tests in pytest.
 - Default statuses: `skipped` (failed xfail) and `passed` (successful xfail).
 - Configuration values can be set via `qase.config.json` or environment variables:
-    - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
-    - `QASE_PYTEST_XFAIL_STATUS_XPASS`
+  - `QASE_PYTEST_XFAIL_STATUS_XFAIL`
+  - `QASE_PYTEST_XFAIL_STATUS_XPASS`
 
 # qase-python-commons@3.2.3
 

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "3.4.3"
+version = "3.4.4"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -111,10 +111,16 @@ class ApiV2Client(ApiV1Client):
 
         try:
             prepared_step = {'execution': {}, 'data': {}, 'steps': []}
-            prepared_step['execution']['status'] = ResultStepStatus(step.execution.status)
-            prepared_step['execution']['duration'] = step.execution.duration
-            prepared_step['execution']['start_time'] = step.execution.start_time
-            prepared_step['execution']['end_time'] = step.execution.end_time
+            if step.execution.status == 'untested':
+                prepared_step['execution']['status'] = ResultStepStatus('skipped')
+                prepared_step['execution']['duration'] = 0
+                prepared_step['execution']['start_time'] = None
+                prepared_step['execution']['end_time'] = None
+            else:
+                prepared_step['execution']['status'] = ResultStepStatus(step.execution.status)
+                prepared_step['execution']['duration'] = step.execution.duration
+                prepared_step['execution']['start_time'] = step.execution.start_time
+                prepared_step['execution']['end_time'] = step.execution.end_time
 
             if step.step_type == StepType.TEXT:
                 prepared_step['data']['action'] = step.data.action


### PR DESCRIPTION
- Updated version to 3.4.4 in pyproject.toml.
- Fixed an issue with the usage of the `pytest.skip` method inside a step body.
- Enhanced execution status handling for untested steps in the API client.