### PR TITLE
feat: add qase.parametrize_ignore decorator for parameter exclusion in reports

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,20 @@
+# qase-pytest 6.3.2
+
+## What's new
+
+Added new decorator `qase.parametrize_ignore` that allows to ignore specific parameters in Qase reports while still collecting other parameters.
+
+```python
+@pytest.mark.parametrize("browser", ["chrome", "firefox", "safari"])
+@qase.parametrize_ignore("test_data", ["data1", "data2", "data3"])
+def test_login(browser, test_data):
+    # test_data will be ignored in Qase report
+    # browser parameter will be included in the report
+    pass
+```
+
+The decorator can be used with any number of parameters. Only parameters specified in `qase.parametrize_ignore` will be excluded from the report.
+
 # qase-pytest 6.3.1
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.1"
+version = "6.3.2"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.4.3",
+    "qase-python-commons~=3.4.4",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -13,6 +13,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config = _add_markers(config)
+    config.addinivalue_line(
+        "markers",
+        "qase_parametrize_ignore: mark test to ignore parameters in Qase reports"
+    )
 
     config_manager = setup_config_manager(config)
 

--- a/qase-pytest/src/qase/pytest/decorators.py
+++ b/qase-pytest/src/qase/pytest/decorators.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Tuple, Union, List
+from typing import Tuple, Union, List, Any, Callable
 
 import pytest
 
@@ -258,3 +258,28 @@ class qase:
         except Exception as e:
             plugin.finish_step(id=id, exception=e)
             raise e
+
+    @staticmethod
+    def parametrize_ignore(argnames: Union[str, List[str]], argvalues: List[Any], ids: List[str] = None):
+        """
+        Extended version of pytest.mark.parametrize that prevents parameter collection for Qase reports.
+        The test will still be reported, but without parameter values.
+
+        >>> @qase.parametrize_ignore(
+        ...     "test_input,expected",
+        ...     [("3+5", 8), ("2+4", 6), ("6*9", 42)],
+        ...     ids=["add_3_5", "add_2_4", "multiply_6_9"]
+        ... )
+        >>> def test_eval(test_input, expected):
+        ...     assert eval(test_input) == expected
+
+        :param argnames: A comma-separated string or list of strings denoting one or more argument names
+        :param argvalues: The list of argvalues to use for the parametrized test
+        :param ids: Optional list of test IDs
+        :return: pytest.mark instance
+        """
+        def decorator(func):
+            func = pytest.mark.parametrize(argnames, argvalues, ids=ids)(func)
+            func = pytest.mark.qase_parametrize_ignore(argnames=argnames)(func)
+            return func
+        return decorator


### PR DESCRIPTION
- Introduced a new decorator `qase.parametrize_ignore` to ignore specific parameters in Qase reports while still collecting others.
- Updated version to 6.3.2 in pyproject.toml.
- Enhanced configuration to recognize the new marker for ignored parameters.
- Improved parameter handling in the plugin to exclude ignored parameters from reports.