### PR TITLE
docs: add usage documentation for Qase integration in Pytest, Robot Framework, and Tavern

### DIFF
--- a/qase-pytest/docs/usage.md
+++ b/qase-pytest/docs/usage.md
@@ -1,0 +1,294 @@
+# Qase Integration in Pytest
+
+This guide demonstrates how to integrate Qase with Pytest, providing instructions on how to add Qase IDs, fields, suites, and other metadata to your test cases.
+
+---
+
+## Adding QaseID to a Test
+
+To associate a QaseID with a test in Pytest, use the `@qase.id` decorator.
+
+```python
+from qase.pytest import qase
+
+@qase.id(1)
+def test_example():
+    assert True
+
+@qase.id([2, 3])  # Multiple IDs
+def test_multiple_ids():
+    assert True
+```
+
+---
+
+## Adding Title to a Test
+
+To set a custom title for a test case:
+
+```python
+from qase.pytest import qase
+
+@qase.title("User Login Test")
+def test_login():
+    assert True
+```
+
+---
+
+## Adding Fields to a Test
+
+The `qase.fields` decorator allows you to add additional metadata to a test case.
+
+```python
+from qase.pytest import qase
+
+@qase.fields(
+    ("priority", "high"),
+    ("severity", "critical"),
+    ("layer", "UI"),
+    ("custom_field", "custom_value")
+)
+def test_example():
+    assert True
+```
+
+---
+
+## Adding a Suite to a Test
+
+To assign a suite or sub-suite to a test:
+
+```python
+from qase.pytest import qase
+
+@qase.suite("Authentication")
+def test_login():
+    assert True
+
+@qase.suite("Authentication", "Login")  # With description
+def test_login_with_description():
+    assert True
+```
+
+### Nested Suites
+
+You can create nested suites using dot notation:
+
+```python
+from qase.pytest import qase
+
+@qase.suite("Authentication.Login")
+def test_login():
+    assert True
+
+@qase.suite("Authentication.Logout")
+def test_logout():
+    assert True
+```
+
+---
+
+## Ignoring a Test in Qase
+
+To exclude a test from being reported to Qase (while still executing the test):
+
+```python
+from qase.pytest import qase
+
+@qase.ignore()
+def test_example():
+    assert True
+```
+
+---
+
+## Muting a Test
+
+To mark a test as muted (it will not affect the test run status):
+
+### Using Decorator
+
+```python
+from qase.pytest import qase
+
+@qase.muted()
+def test_example():
+    assert True
+```
+
+---
+
+## Working with Parameters
+
+### Ignoring Parameters
+
+To exclude specific parameters from Qase reports. Only `param1` and `param2` will be reported.
+
+```python
+from qase.pytest import qase
+
+@qase.parametrize_ignore(
+    "test_input,expected",
+    [("3+5", 8), ("2+4", 6), ("6*9", 42)],
+    ids=["add_3_5", "add_2_4", "multiply_6_9"]
+)
+@pytest.mark.parametrize(
+    "param1,param2", 
+    [(1, 2), (3, 4), (5, 6)], 
+    ids=["param1_1_2", "param1_3_4", "param1_5_6"])
+def test_eval(test_input, expected, param1, param2):
+    print(param1, param2)
+    assert eval(test_input) == expected
+```
+
+---
+
+## Advanced Configuration
+
+### Profilers
+
+Enable profilers to collect additional data:
+
+#### Sleep Profiler
+
+Sleep profiler is a special profiler that allows you to measure the time taken by the test. Each sleep will be reported as a separate step with the duration of the sleep.
+
+```bash
+pytest --qase-profilers=sleep
+```
+
+```python
+from qase.pytest import qase
+
+def test_example():
+    time.sleep(1)
+    assert True
+```
+
+#### Network Profiler
+
+Network profiler is a special profiler that allows you to measure the time taken by the network requests. Each network request will be reported as a separate step with the request details.
+
+```bash
+pytest --qase-profilers=network
+```
+
+```python
+import requests
+
+def test_example():
+    requests.get("https://api.qase.io/v1/projects")
+    assert True
+```
+
+---
+
+### Log Capture
+
+Capture pytest logs. All logs will be reported as a attachment to the test case.
+
+```bash
+pytest --qase-pytest-capture-logs=true
+```
+
+### XFail Status
+
+Configure xfail status mapping:
+
+```bash
+pytest --qase-pytest-xfail-status-xfail=skipped
+```
+
+---
+
+## Execution Plans
+
+You can use execution plans to run only specific tests:
+
+```bash
+pytest --qase-execution-plan-path=plan.json
+```
+
+The execution plan file should contain a list of Qase IDs:
+
+```json
+[1, 2, 3, 4, 5]
+```
+
+---
+
+## Multiple Decorators
+
+You can combine multiple decorators:
+
+```python
+from qase.pytest import qase
+
+@qase.id(1)
+@qase.title("User Login Test")
+@qase.suite("Authentication")
+@qase.fields(
+    ("priority", "high"),
+    ("severity", "critical"),
+    ("layer", "UI")
+)
+def test_login():
+    assert True
+```
+
+---
+
+## Examples
+
+### Complete Test Example
+
+```python
+import pytest
+from qase.pytest import qase
+
+@qase.id(1)
+@qase.title("User Registration Test")
+@qase.suite("Authentication.Registration")
+@qase.fields(
+    ("priority", "high"),
+    ("severity", "critical"),
+    ("layer", "UI")
+)
+def test_user_registration():
+    # Test implementation
+    assert True
+
+@qase.id([2, 3])
+@qase.title("User Login Test")
+@qase.suite("Authentication.Login")
+@qase.ignore()  # This test will be ignored in Qase
+def test_user_login():
+    # Test implementation
+    assert True
+
+@qase.parametrize_ignore(
+    "email,password",
+    [("user1@example.com", "pass1"), ("user2@example.com", "pass2")],
+    ids=["user1", "user2"]
+)
+def test_login_with_different_users(email, password):
+    # Test implementation
+    assert True
+```
+
+### Running Tests
+
+```bash
+# Basic run
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN
+
+# With environment and plan
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-environment=staging --qase-testops-plan-id=123
+
+# With execution plan
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-execution-plan-path=plan.json
+
+# With profilers and logs
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-profilers=network,db --qase-pytest-capture-logs=true
+```

--- a/qase-robotframework/docs/usage.md
+++ b/qase-robotframework/docs/usage.md
@@ -1,0 +1,227 @@
+# Qase Integration in Robot Framework
+
+This guide demonstrates how to integrate Qase with Robot Framework, providing instructions on how to add Qase IDs, fields, and other metadata to your test cases.
+
+## Adding QaseID to a Test
+
+To associate a QaseID with a test in Robot Framework, use the `Q-{ID}` tag format.
+
+```robotframework
+*** Test Cases ***
+Test with QaseID
+    [Tags]    Q-10
+    Step 01
+    Step 02
+    Passed step
+
+Test with multiple QaseIDs
+    [Tags]    Q-11    Q-12
+    Step 01
+    Step 02
+    Passed step
+```
+
+---
+
+## Adding Fields to a Test
+
+The `qase.fields` tag allows you to add additional metadata to a test case using JSON format.
+
+```robotframework
+*** Test Cases ***
+Test with fields
+    [Tags]    qase.fields:{"priority": "high", "severity": "critical", "layer": "UI"}
+    Step 01
+    Step 02
+    Passed step
+
+Test with description and preconditions
+    [Tags]    qase.fields:{"description": "User login test", "preconditions": "User is not logged in"}
+    Step 01
+    Step 02
+    Passed step
+```
+
+### Available Fields
+
+You can add any custom fields, but some common ones include:
+
+- `description` - Description of the test case
+- `preconditions` - Preconditions for the test case
+- `postconditions` - Postconditions for the test case
+- `severity` - Severity of the test case (e.g., `critical`, `major`)
+- `priority` - Priority of the test case (e.g., `high`, `low`)
+- `layer` - Test layer (e.g., `UI`, `API`)
+
+---
+
+## Adding Parameters to a Test
+
+The `qase.params` tag allows you to specify which Robot Framework variables should be reported as parameters.
+
+```robotframework
+*** Variables ***
+${username}    testuser
+${password}    testpass
+${browser}     chrome
+
+*** Test Cases ***
+Login Test
+    [Tags]    qase.params:[username, password]
+    Login with credentials    ${username}    ${password}
+    Verify login successful
+
+Browser Test
+    [Tags]    qase.params:[browser]
+    Open browser    ${browser}
+    Navigate to page
+    Close browser
+```
+
+---
+
+## Ignoring a Test in Qase
+
+To exclude a test from being reported to Qase (while still executing the test), use the `qase.ignore` tag.
+
+```robotframework
+*** Test Cases ***
+Ignored test
+    [Tags]    qase.ignore
+    Step 01
+    Step 02
+    Passed step
+```
+
+---
+
+## Combining Multiple Tags
+
+You can combine multiple Qase tags in a single test:
+
+```robotframework
+*** Test Cases ***
+Complete test with all metadata
+    [Tags]    Q-15    qase.fields:{"priority": "high", "severity": "critical"}    qase.params:[username, password]
+    Step 01
+    Step 02
+    Passed step
+```
+
+---
+
+## Test Documentation
+
+Robot Framework automatically uses the test documentation as the test description in Qase:
+
+```robotframework
+*** Test Cases ***
+User Login Test
+    [Documentation]    Test user login functionality with valid credentials
+    [Tags]    Q-20
+    Step 01
+    Step 02
+    Passed step
+```
+
+---
+
+## Advanced Configuration
+
+### Parallel Execution
+
+For parallel execution with pabot, the plugin automatically handles worker coordination:
+
+```bash
+pabot --listener qase.robotframework.Listener --variable QASE_TESTOPS_PROJECT:PROJECT_CODE --variable QASE_TESTOPS_API_TOKEN:YOUR_TOKEN tests/
+```
+
+---
+
+## Examples
+
+### Complete Test Suite Example
+
+```robotframework
+*** Settings ***
+Library    SeleniumLibrary
+Library    steps.py
+
+*** Variables ***
+${base_url}    https://example.com
+${username}    testuser
+${password}    testpass
+
+*** Test Cases ***
+User Registration Test
+    [Documentation]    Test user registration with valid data
+    [Tags]    Q-1    qase.fields:{"priority": "high", "severity": "critical", "layer": "UI"}
+    [Setup]    Open browser    ${base_url}    chrome
+    Navigate to registration page
+    Fill registration form    ${username}    ${password}
+    Submit registration form
+    Verify registration successful
+    [Teardown]    Close browser
+
+User Login Test
+    [Documentation]    Test user login with valid credentials
+    [Tags]    Q-2    qase.params:[username, password]
+    [Setup]    Open browser    ${base_url}    chrome
+    Navigate to login page
+    Fill login form    ${username}    ${password}
+    Submit login form
+    Verify login successful
+    [Teardown]    Close browser
+
+Ignored Test
+    [Documentation]    This test is ignored in Qase
+    [Tags]    qase.ignore
+    Step 01
+    Step 02
+    Passed step
+
+*** Keywords ***
+Navigate to registration page
+    Go to    ${base_url}/register
+
+Fill registration form
+    [Arguments]    ${username}    ${password}
+    Input text    id=username    ${username}
+    Input text    id=password    ${password}
+
+Submit registration form
+    Click button    id=submit
+
+Verify registration successful
+    Page should contain    Registration successful
+
+Navigate to login page
+    Go to    ${base_url}/login
+
+Fill login form
+    [Arguments]    ${username}    ${password}
+    Input text    id=username    ${username}
+    Input text    id=password    ${password}
+
+Submit login form
+    Click button    id=submit
+
+Verify login successful
+    Page should contain    Welcome
+```
+
+### Running Tests
+
+```bash
+# Basic run
+robot --listener qase.robotframework.Listener --variable QASE_TESTOPS_PROJECT:MYPROJECT --variable QASE_TESTOPS_API_TOKEN:YOUR_TOKEN tests/
+
+# With environment and plan
+robot --listener qase.robotframework.Listener --variable QASE_TESTOPS_PROJECT:MYPROJECT --variable QASE_TESTOPS_API_TOKEN:YOUR_TOKEN --variable QASE_ENVIRONMENT:staging --variable QASE_TESTOPS_PLAN_ID:123 tests/
+
+# With execution plan
+robot --listener qase.robotframework.Listener --variable QASE_TESTOPS_PROJECT:MYPROJECT --variable QASE_TESTOPS_API_TOKEN:YOUR_TOKEN --variable QASE_EXECUTION_PLAN_PATH:plan.json tests/
+
+# Parallel execution
+pabot --listener qase.robotframework.Listener --variable QASE_TESTOPS_PROJECT:MYPROJECT --variable QASE_TESTOPS_API_TOKEN:YOUR_TOKEN tests/
+```

--- a/qase-tavern/docs/usage.md
+++ b/qase-tavern/docs/usage.md
@@ -1,0 +1,148 @@
+# Qase Integration in Tavern
+
+This guide demonstrates how to integrate Qase with Tavern, providing instructions on how to add Qase IDs and other metadata to your API test cases.
+
+---
+
+## Adding QaseID to a Test
+
+To associate a QaseID with a test in Tavern, include `QaseID={ID}` in the test name.
+
+```yaml
+---
+test_name: QaseID=1 Get user by ID
+
+stages:
+  - name: Get user
+    request:
+      url: https://api.example.com/users/1
+      method: GET
+    response:
+      status_code: 200
+      json:
+        id: 1
+        name: "John Doe"
+        email: "john@example.com"
+```
+
+### Multiple Qase IDs
+
+You can associate multiple Qase IDs with a single test by separating them with commas:
+
+```yaml
+---
+test_name: QaseID=1,2,3 Get user by ID
+
+stages:
+  - name: Get user
+    request:
+      url: https://api.example.com/users/1
+      method: GET
+    response:
+      status_code: 200
+      json:
+        id: 1
+        name: "John Doe"
+        email: "john@example.com"
+```
+
+---
+
+## Examples
+
+### Complete Test File Example
+
+```yaml
+---
+test_name: QaseID=1 Get user by ID success
+
+stages:
+  - name: Get user
+    request:
+      url: https://jsonplaceholder.typicode.com/posts/1
+      method: GET
+    response:
+      status_code: 200
+      json:
+        id: 1
+        userId: 1
+        title: "sunt aut facere repellat provident occaecati excepturi optio reprehenderit"
+        body: "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+
+---
+test_name: QaseID=2 Get user by ID failed
+
+stages:
+  - name: Get user
+    request:
+      url: https://jsonplaceholder.typicode.com/posts/1
+      method: GET
+    response:
+      status_code: 300  # This will cause the test to fail
+      json:
+        id: 1
+        userId: 1
+        title: "sunt aut facere repellat provident occaecati excepturi optio reprehenderit"
+        body: "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
+
+---
+test_name: QaseID=3,4 User authentication flow
+
+stages:
+  - name: Login user
+    request:
+      url: https://api.example.com/auth/login
+      method: POST
+      json:
+        username: "testuser"
+        password: "testpass"
+    response:
+      status_code: 200
+      json:
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+  - name: Get user profile
+    request:
+      url: https://api.example.com/user/profile
+      method: GET
+      headers:
+        Authorization: "Bearer {token}"
+    response:
+      status_code: 200
+      json:
+        id: 1
+        name: "Test User"
+        email: "test@example.com"
+
+  - name: Update user profile
+    request:
+      url: https://api.example.com/user/profile
+      method: PUT
+      headers:
+        Authorization: "Bearer {token}"
+      json:
+        name: "Updated User"
+        email: "updated@example.com"
+    response:
+      status_code: 200
+      json:
+        id: 1
+        name: "Updated User"
+        email: "updated@example.com"
+```
+
+### Running Tests
+
+```bash
+# Basic run
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN test_file.tavern.yaml
+
+# With environment and plan
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-environment=staging --qase-testops-plan-id=123 test_file.tavern.yaml
+
+# With execution plan
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-execution-plan-path=plan.json test_file.tavern.yaml
+
+# With profilers and logs
+pytest --qase-mode=testops --qase-testops-project=MYPROJECT --qase-testops-api-token=YOUR_TOKEN --qase-profilers=network,db --qase-pytest-capture-logs=true test_file.tavern.yaml
+```


### PR DESCRIPTION
- Introduced comprehensive usage guides for integrating Qase with Pytest, Robot Framework, and Tavern.
- Included examples for adding Qase IDs, fields, and other metadata to test cases.
- Enhanced documentation to facilitate user understanding of the integration process.