### PR TITLE
chore: update version to 1.2.2 and adjust urllib3 dependency

### DIFF
--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "1.2.1"
+version = "1.2.2"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.7"
 dependencies = [
-    "urllib3 >= 1.25.3, < 2.3.0",
+    "urllib3 >= 1.25.3, <= 2.5.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "1.2.1"
+version = "1.2.2"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.7"
 dependencies = [
-    "urllib3 >= 1.25.3, < 2.3.0",
+    "urllib3 >= 1.25.3, <= 2.5.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",


### PR DESCRIPTION
- Updated version to 1.2.2 in pyproject.toml for both qase-api-client and qase-api-v2-client.
- Changed urllib3 dependency version to >= 2.5.0 for compatibility.