### PR TITLE
feat: add ignore_parameters decorator for Qase reports

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,31 @@
+# qase-pytest 6.3.6
+
+## What's new
+
+- Added new decorator `qase.ignore_parameters` that allows to ignore specific parameters in Qase reports.
+- The decorator can be used in combination with existing `qase.parametrize_ignore` decorator.
+- Support for ignoring multiple parameters at once.
+
+```python
+@pytest.mark.parametrize("browser", ["chrome", "firefox"])
+@pytest.mark.parametrize("user", ["user1", "user2"])
+@qase.ignore_parameters("user", "browser")
+def test_login(browser, user):
+    # Both browser and user parameters will be ignored in Qase reports
+    pass
+```
+
+You can also ignore only specific parameters:
+
+```python
+@pytest.mark.parametrize("browser", ["chrome", "firefox"])
+@pytest.mark.parametrize("user", ["user1", "user2"])
+@qase.ignore_parameters("user")
+def test_login(browser, user):
+    # Only user parameter will be ignored, browser will be included
+    pass
+```
+
 # qase-pytest 6.3.5
 
 ## What's new

--- a/qase-pytest/docs/usage.md
+++ b/qase-pytest/docs/usage.md
@@ -123,7 +123,11 @@ def test_example():
 
 ### Ignoring Parameters
 
-To exclude specific parameters from Qase reports. Only `param1` and `param2` will be reported.
+There are two ways to exclude specific parameters from Qase reports:
+
+#### Using parametrize_ignore
+
+To exclude parameters from a specific parametrize decorator:
 
 ```python
 from qase.pytest import qase
@@ -140,6 +144,54 @@ from qase.pytest import qase
 def test_eval(test_input, expected, param1, param2):
     print(param1, param2)
     assert eval(test_input) == expected
+```
+
+#### Using ignore_parameters
+
+To exclude specific parameters from any parametrize decorator:
+
+```python
+from qase.pytest import qase
+
+@pytest.mark.parametrize("browser", ["chrome", "firefox"])
+@pytest.mark.parametrize("user", ["user1", "user2"])
+@qase.ignore_parameters("user", "browser")
+def test_login(browser, user):
+    # Both browser and user parameters will be ignored in Qase reports
+    assert browser in ["chrome", "firefox"]
+    assert user in ["user1", "user2"]
+```
+
+You can also ignore only specific parameters:
+
+```python
+from qase.pytest import qase
+
+@pytest.mark.parametrize("browser", ["chrome", "firefox"])
+@pytest.mark.parametrize("user", ["user1", "user2"])
+@pytest.mark.parametrize("env", ["staging", "production"])
+@qase.ignore_parameters("user")
+def test_login(browser, user, env):
+    # Only user parameter will be ignored, browser and env will be included
+    assert browser in ["chrome", "firefox"]
+    assert user in ["user1", "user2"]
+    assert env in ["staging", "production"]
+```
+
+#### Combining both approaches
+
+You can use both decorators together:
+
+```python
+from qase.pytest import qase
+
+@qase.parametrize_ignore("test_data", ["data1", "data2"])
+@pytest.mark.parametrize("browser", ["chrome", "firefox"])
+@qase.ignore_parameters("browser")
+def test_combined(browser, test_data):
+    # Both test_data (from parametrize_ignore) and browser (from ignore_parameters) will be ignored
+    assert browser in ["chrome", "firefox"]
+    assert test_data in ["data1", "data2"]
 ```
 
 ---

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.5"
+version = "6.3.6"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -40,6 +40,8 @@ def _add_markers(config):
     config.addinivalue_line("markers", "qase_author: mark test with author")
     config.addinivalue_line("markers", "qase_fields: mark test with meta data")
     config.addinivalue_line("markers", "qase_suite: mark test with suite")
+    config.addinivalue_line(
+        "markers", "qase_ignore_parameters: mark test to ignore specific parameters in Qase reports")
 
     # Legacy markers | These markers are deprecated and will be removed in future versions
     config.addinivalue_line(

--- a/qase-pytest/src/qase/pytest/decorators.py
+++ b/qase-pytest/src/qase/pytest/decorators.py
@@ -293,3 +293,28 @@ class qase:
             return func
 
         return decorator
+
+    @staticmethod
+    def ignore_parameters(*parameters: str):
+        """
+        Mark specific parameters to be ignored in Qase reports.
+        This decorator can be used in combination with existing parametrize decorators.
+
+        >>> @pytest.mark.parametrize("browser", ["chrome", "firefox"])
+        ... @pytest.mark.parametrize("user", ["user1", "user2"])
+        ... @qase.ignore_parameters("user", "browser")
+        ... def test_login(browser, user):
+        ...     # Both browser and user parameters will be ignored in Qase reports
+        ...     pass
+
+        >>> @pytest.mark.parametrize("browser", ["chrome", "firefox"])
+        ... @pytest.mark.parametrize("user", ["user1", "user2"])
+        ... @qase.ignore_parameters("user")
+        ... def test_login(browser, user):
+        ...     # Only user parameter will be ignored, browser will be included
+        ...     pass
+
+        :param parameters: Variable number of parameter names to ignore
+        :return: pytest.mark instance
+        """
+        return pytest.mark.qase_ignore_parameters(parameters=parameters)

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -404,6 +404,10 @@ class QasePytestPlugin:
                                 [p.strip() for p in param_name.split(',')])
                         else:
                             ignored_params.add(param_name)
+                elif mark.name == 'qase_ignore_parameters':
+                    parameters = mark.kwargs.get('parameters', [])
+                    if parameters:
+                        ignored_params.update(parameters)
 
             # Add grouped parameters that are not ignored
             for group in item._grouped_params:


### PR DESCRIPTION
- Introduced a new decorator `qase.ignore_parameters` to allow specific parameters to be ignored in Qase reports.
- Updated documentation to include usage examples for the new decorator.
- Enhanced changelog to reflect the addition of this feature and updated version to 6.3.6 in pyproject.toml.