### PR TITLE
feat: release version 6.3.7 with skip message handling improvements

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 6.3.7
+
+## What's new
+
+Fixed an issue where the plugin would crash with `TypeError: 'ExceptionChainRepr' object is not subscriptable` when handling skip messages in newer versions of pytest. The plugin now properly handles both tuple/list format longrepr (old pytest versions) and ExceptionChainRepr format (new pytest versions) for skip message extraction.
+
 # qase-pytest 6.3.6
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.6"
+version = "6.3.7"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]


### PR DESCRIPTION
- Fixed a crash issue with `TypeError: 'ExceptionChainRepr' object is not subscriptable` when handling skip messages in newer pytest versions.
- Enhanced the plugin to properly handle both old and new formats of longrepr for skip message extraction.
- Updated version to 6.3.7 in pyproject.toml and added changes to the changelog.

Fixed #385