### PR TITLE
feat: release versions with status filtering support

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,9 @@
+# qase-behave 1.1.5
+
+## What's new
+
+- Added support for filtering test results by status.
+
 # qase-behave 1.1.4
 
 ## What's new

--- a/qase-behave/docs/CONFIGURATION.md
+++ b/qase-behave/docs/CONFIGURATION.md
@@ -35,7 +35,59 @@ and command line options override both other values.
 | Test run tags                             | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `qase-testops-run-tags`         | None, don't add any tags                | No       | Comma-separated list of tags |
 | Test run configurations                   | `testops.configurations.values` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `qase-testops-configurations-values` | None, don't add any configurations      | No       | Format: "group1=value1,group2=value2" |
 | Create configurations if not exists       | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `qase-testops-configurations-create-if-not-exists` | `False`, don't create configurations     | No       | `True`, `False`            |
+| Filter results by status                  | `testops.statusFilter`     | `QASE_TESTOPS_STATUS_FILTER`    | `qase-testops-status-filter`    | None, don't filter any results          | No       | Comma-separated list of statuses |
 | **Qase Report mode configuration**        |
 | Local path to store report                | `report.connection.path`   | `QASE_REPORT_CONNECTION_PATH`   | `qase-report-connection-path`   | `./build/qase-report`                   | No       | Any string                 |
 | Report format                             | `report.connection.format` | `QASE_REPORT_CONNECTION_FORMAT` | `qase-report-connection-format` | `json`                                  | No       | `json`, `jsonp`            |
 | Driver used for report mode               | `report.driver`            | `QASE_REPORT_DRIVER`            | `qase-report-driver`            | `local`                                 | No       | `local`                    |
+
+## Example `qase.config.json` config:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "debug": false,
+  "environment": "local",
+  "report": {
+    "driver": "local",
+    "connection": {
+      "local": {
+        "path": "./build/qase-report",
+        "format": "json"
+      }
+    }
+  },
+  "testops": {
+    "api": {
+      "token": "<token>",
+      "host": "qase.io"
+    },
+    "run": {
+      "title": "Regress run",
+      "description": "Regress run description",
+      "complete": true,
+      "tags": ["tag1", "tag2"]
+    },
+    "defect": false,
+    "project": "<project_code>",
+    "batch": {
+      "size": 100
+    },
+    "statusFilter": ["passed", "failed"],
+    "configurations": {
+      "values": [
+        {
+          "name": "group1",
+          "value": "value1"
+        },
+        {
+          "name": "group2", 
+          "value": "value2"
+        }
+      ],
+      "createIfNotExists": true
+    }
+  }
+}
+```

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.1.4"
+version = "1.1.5"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.3",
+    "qase-python-commons~=3.5.4",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/formatter.py
+++ b/qase-behave/src/qase/behave/formatter.py
@@ -146,6 +146,10 @@ class QaseFormatter(Formatter):
             cfg_mgr.config.testops.configurations.set_create_if_not_exists(
                 userdata['qase-testops-configurations-create-if-not-exists'])
 
+        if 'qase-testops-status-filter' in userdata:
+            cfg_mgr.config.testops.set_status_filter(
+                [status.strip() for status in userdata['qase-testops-status-filter'].split(',')])
+
         if 'qase-report-driver' in userdata:
             cfg_mgr.config.report.set_driver(userdata['qase-report-driver'])
 

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 6.3.8
+
+## What's new
+
+- Added support for filtering test results by status.
+
 # qase-pytest 6.3.7
 
 ## What's new

--- a/qase-pytest/docs/CONFIGURATION.md
+++ b/qase-pytest/docs/CONFIGURATION.md
@@ -35,6 +35,7 @@ and command line options override both other values.
 | Test run tags                                  | `testops.run.tags`                   | `QASE_TESTOPS_RUN_TAGS`          | `--qase-testops-run-tags`          | None, don't add any tags                | No       | Comma-separated list of tags |
 | Test run configurations                        | `testops.configurations.values`      | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `--qase-testops-configurations-values` | None, don't add any configurations      | No       | Format: "group1=value1,group2=value2" |
 | Create configurations if not exists            | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `--qase-testops-configurations-create-if-not-exists` | `False`, don't create configurations     | No       | `True`, `False`            |
+| Filter results by status                      | `testops.statusFilter`                | `QASE_TESTOPS_STATUS_FILTER`     | `--qase-testops-status-filter`     | None, don't filter any results          | No       | Comma-separated list of statuses |
 | **Qase Report mode configuration**             |
 | Local path to store report                     | `report.connection.path`             | `QASE_REPORT_CONNECTION_PATH`    | `--qase-report-connection-path`    | `./build/qase-report`                   | No       | Any string                 |
 | Report format                                  | `report.connection.format`           | `QASE_REPORT_CONNECTION_FORMAT`  | `--qase-report-connection-format`  | `json`                                  | No       | `json`, `jsonp`            |
@@ -48,3 +49,54 @@ and command line options override both other values.
 | **qase-pytest v5.x**                           |
 | TestOps bulk (always on since v6)              | `testops.bulk`                       | `QASE_TESTOPS_BULK`              | `--qase-testops-bulk`              | `True`                                  | No       | `true`, `false`            |
 | Execution chunk size (changed to `batch.size`) | `testops.chunk`                      | `QASE_TESTOPS_CHUNK`             | `--qase-testops-chunk`             | 200                                     | No       | 1 to 2000                  |
+
+## Example `qase.config.json` config:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "debug": false,
+  "environment": "local",
+  "report": {
+    "driver": "local",
+    "connection": {
+      "local": {
+        "path": "./build/qase-report",
+        "format": "json"
+      }
+    }
+  },
+  "testops": {
+    "api": {
+      "token": "<token>",
+      "host": "qase.io"
+    },
+    "run": {
+      "title": "Regress run",
+      "description": "Regress run description",
+      "complete": true,
+      "tags": ["tag1", "tag2"]
+    },
+    "defect": false,
+    "project": "<project_code>",
+    "batch": {
+      "size": 100
+    },
+    "statusFilter": ["passed", "failed"],
+    "configurations": {
+      "values": [
+        {
+          "name": "group1",
+          "value": "value1"
+        },
+        {
+          "name": "group2", 
+          "value": "value2"
+        }
+      ],
+      "createIfNotExists": true
+    }
+  }
+}
+```

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.7"
+version = "6.3.8"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.3",
+    "qase-python-commons~=3.5.4",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -186,6 +186,10 @@ def setup_config_manager(config):
                 config_manager.config.testops.configurations.set_create_if_not_exists(
                     config.option.__dict__[option])
 
+            if option == "qase_testops_status_filter" and config.option.__dict__[option] is not None:
+                config_manager.config.testops.set_status_filter(
+                    [status.strip() for status in config.option.__dict__[option].split(',')])
+
     return config_manager
 
 

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -162,6 +162,14 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-status-filter",
+            dest="qase_testops_status_filter",
+            help="Filter results by status. Format: 'passed,failed,skipped'"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-report-driver",
             dest="qase_report_driver",
             help="Define report driver: `local`. More options coming soon."

--- a/qase-robotframework/docs/CONFIGURATION.md
+++ b/qase-robotframework/docs/CONFIGURATION.md
@@ -32,7 +32,59 @@ Environment variables override the values given in the config file.
 | Test run tags                             | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | None, don't add any tags                | No       | Comma-separated list of tags |
 | Test run configurations                   | `testops.configurations.values` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | None, don't add any configurations      | No       | Format: "group1=value1,group2=value2" |
 | Create configurations if not exists       | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `False`, don't create configurations     | No       | `True`, `False`            |
+| Filter results by status                  | `testops.statusFilter`     | `QASE_TESTOPS_STATUS_FILTER`    | None, don't filter any results          | No       | Comma-separated list of statuses |
 | **Qase Report mode configuration**        |
 | Local path to store report                | `report.connection.path`   | `QASE_REPORT_CONNECTION_PATH`   | `./build/qase-report`                   | No       | Any string                 |
 | Report format                             | `report.connection.format` | `QASE_REPORT_CONNECTION_FORMAT` | `json`                                  | No       | `json`, `jsonp`            |
 | Driver used for report mode               | `report.driver`            | `QASE_REPORT_DRIVER`            | `local`                                 | No       | `local`                    |
+
+## Example `qase.config.json` config:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "debug": false,
+  "environment": "local",
+  "report": {
+    "driver": "local",
+    "connection": {
+      "local": {
+        "path": "./build/qase-report",
+        "format": "json"
+      }
+    }
+  },
+  "testops": {
+    "api": {
+      "token": "<token>",
+      "host": "qase.io"
+    },
+    "run": {
+      "title": "Regress run",
+      "description": "Regress run description",
+      "complete": true,
+      "tags": ["tag1", "tag2"]
+    },
+    "defect": false,
+    "project": "<project_code>",
+    "batch": {
+      "size": 100
+    },
+    "statusFilter": ["passed", "failed"],
+    "configurations": {
+      "values": [
+        {
+          "name": "group1",
+          "value": "value1"
+        },
+        {
+          "name": "group2", 
+          "value": "value2"
+        }
+      ],
+      "createIfNotExists": true
+    }
+  }
+}
+```

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,9 @@
+# qase-tavern 1.1.3
+
+## What's new
+
+- Added support for filtering test results by status.
+
 # qase-tavern 1.1.2
 
 ## What's new
@@ -7,6 +13,7 @@
 - Support for automatic creation of configurations if they don't exist (controlled by `createIfNotExists` option).
 
 Example configuration:
+
 ```json
 {
   "testops": {
@@ -36,39 +43,7 @@ CLI parameter format: `--qase-testops-configurations-values="browser=chrome,envi
 
 - Added support for test run tags.
 - Added support for excluding parameters from test results.
-
-# qase-tavern 1.1.2
-
-## What's new
-
-- Added support for test run configurations. You can now specify configurations when creating test runs.
-- Configurations can be specified in `qase.config.json`, environment variables, or CLI parameters.
-- Support for automatic creation of configurations if they don't exist (controlled by `createIfNotExists` option).
-
-Example configuration:
-```json
-{
-  "testops": {
-    "configurations": {
-      "values": [
-        {
-          "name": "browser",
-          "value": "chrome"
-        },
-        {
-          "name": "environment", 
-          "value": "staging"
-        }
-      ],
-      "createIfNotExists": true
-    }
-  }
-}
-```
-
-Environment variable format: `QASE_TESTOPS_CONFIGURATIONS_VALUES="browser=chrome,environment=staging"`
-CLI parameter format: `--qase-testops-configurations-values="browser=chrome,environment=staging"`
-
+  
 # qase-tavern 1.1.0
 
 ## What's new

--- a/qase-tavern/docs/CONFIGURATION.md
+++ b/qase-tavern/docs/CONFIGURATION.md
@@ -35,7 +35,59 @@ and command line options override both other values.
 | Tags for test run                         | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `--qase-testops-run-tags`         | None                                    | No       | Comma-separated list of tags |
 | Test run configurations                   | `testops.configurations.values` | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `--qase-testops-configurations-values` | None, don't add any configurations      | No       | Format: "group1=value1,group2=value2" |
 | Create configurations if not exists       | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `--qase-testops-configurations-create-if-not-exists` | `False`, don't create configurations     | No       | `True`, `False`            |
+| Filter results by status                  | `testops.statusFilter`     | `QASE_TESTOPS_STATUS_FILTER`    | `--qase-testops-status-filter`    | None, don't filter any results          | No       | Comma-separated list of statuses |
 | **Qase Report mode configuration**        |
 | Local path to store report                | `report.connection.path`   | `QASE_REPORT_CONNECTION_PATH`   | `--qase-report-connection-path`   | `./build/qase-report`                   | No       | Any string                 |
 | Report format                             | `report.connection.format` | `QASE_REPORT_CONNECTION_FORMAT` | `--qase-report-connection-format` | `json`                                  | No       | `json`, `jsonp`            |
 | Driver used for report mode               | `report.driver`            | `QASE_REPORT_DRIVER`            | `--qase-report-driver`            | `local`                                 | No       | `local`                    |
+
+## Example `qase.config.json` config:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "debug": false,
+  "environment": "local",
+  "report": {
+    "driver": "local",
+    "connection": {
+      "local": {
+        "path": "./build/qase-report",
+        "format": "json"
+      }
+    }
+  },
+  "testops": {
+    "api": {
+      "token": "<token>",
+      "host": "qase.io"
+    },
+    "run": {
+      "title": "Regress run",
+      "description": "Regress run description",
+      "complete": true,
+      "tags": ["tag1", "tag2"]
+    },
+    "defect": false,
+    "project": "<project_code>",
+    "batch": {
+      "size": 100
+    },
+    "statusFilter": ["passed", "failed"],
+    "configurations": {
+      "values": [
+        {
+          "name": "group1",
+          "value": "value1"
+        },
+        {
+          "name": "group2", 
+          "value": "value2"
+        }
+      ],
+      "createIfNotExists": true
+    }
+  }
+}
+```

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "1.1.2"
+version = "1.1.3"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.3",
+    "qase-python-commons~=3.5.4",
     "pytest>=7,<7.3",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-tavern/src/qase/tavern/conftest.py
+++ b/qase-tavern/src/qase/tavern/conftest.py
@@ -128,6 +128,10 @@ def setup_config_manager(config):
                 config_manager.config.testops.configurations.set_create_if_not_exists(
                     config.option.__dict__[option])
 
+            if option == "qase_testops_status_filter" and config.option.__dict__[option] is not None:
+                config_manager.config.testops.set_status_filter(
+                    [status.strip() for status in config.option.__dict__[option].split(',')])
+
             if option == "qase_testops_defect" and config.option.__dict__[option] is not None:
                 config_manager.config.testops.set_defect(config.option.__dict__[option])
 

--- a/qase-tavern/src/qase/tavern/options.py
+++ b/qase-tavern/src/qase/tavern/options.py
@@ -162,6 +162,14 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-status-filter",
+            dest="qase_testops_status_filter",
+            help="Filter results by status. Format: 'passed,failed,skipped'"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-report-driver",
             dest="qase_report_driver",
             help="Define report driver: `local`. More options coming soon."


### PR DESCRIPTION
- Updated versions in pyproject.toml for qase-behave, qase-pytest, and qase-tavern.
- Added support for filtering test results by status across all plugins.
- Enhanced documentation to include configuration examples for status filtering.
- Updated changelogs to reflect the addition of this feature.