### PR TITLE
feat: release version 1.1.6 with improved test failure status handling

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,21 @@
+# qase-behave 1.1.6
+
+## What's new
+
+- Improved test failure status handling
+- Enhanced error classification to distinguish assertion errors from other failures
+- Assertion errors (containing keywords like 'assert', 'AssertionError', 'expect', 'should', 'must') now map to `failed` status
+- Non-assertion errors (setup failures, exceptions, etc.) now map to `invalid` status
+- Updated dependency on qase-python-commons to version 3.5.5
+
+## Migration Guide
+
+The formatter now provides more accurate test result reporting by distinguishing between:
+- `failed`: Test failed due to assertion error (test logic issue)
+- `invalid`: Test failed due to non-assertion error (infrastructure/setup issue)
+
+This change provides better insights into test failures and helps identify whether issues are related to test logic or infrastructure problems.
+
 # qase-behave 1.1.5
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.1.5"
+version = "1.1.6"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.4",
+    "qase-python-commons~=3.5.5",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -111,7 +111,17 @@ def parse_step(step: Step) -> QaseStep:
     )
 
     current_time = time.time()
-    model.execution.set_status(step.status.name)
+    
+    # Map behave status to qase status
+    status_mapping = {
+        'passed': 'passed',
+        'failed': 'failed',  # This will be updated in formatter based on error type
+        'skipped': 'skipped',
+        'undefined': 'skipped',
+        'pending': 'skipped'
+    }
+    
+    model.execution.set_status(status_mapping.get(step.status.name, 'skipped'))
     model.execution.start_time = current_time - step.duration
     model.execution.duration = int(step.duration * 1000)
     model.execution.end_time = current_time

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,21 @@
+# qase-pytest 6.3.9
+
+## What's new
+
+- Improved test failure status handling
+- Enhanced error classification to distinguish assertion errors from other failures
+- Assertion errors (AssertionError) now map to `failed` status
+- Non-assertion errors (setup failures, exceptions, etc.) now map to `invalid` status
+- Updated dependency on qase-python-commons to version 3.5.5
+
+## Migration Guide
+
+The plugin now provides more accurate test result reporting by distinguishing between:
+- `failed`: Test failed due to assertion error (test logic issue)
+- `invalid`: Test failed due to non-assertion error (infrastructure/setup issue)
+
+This change provides better insights into test failures and helps identify whether issues are related to test logic or infrastructure problems.
+
 # qase-pytest 6.3.8
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.8"
+version = "6.3.9"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.4",
+    "qase-python-commons~=3.5.5",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,21 @@
+# qase-robotframework 3.4.5
+
+## What's new
+
+- Improved test failure status handling
+- Enhanced error classification to distinguish assertion errors from other failures
+- Assertion errors (containing keywords like 'assert', 'AssertionError', 'expect', 'should', 'must', 'equal', 'not equal') now map to `failed` status
+- Non-assertion errors (setup failures, exceptions, etc.) now map to `invalid` status
+- Updated dependency on qase-python-commons to version 3.5.5
+
+## Migration Guide
+
+The listener now provides more accurate test result reporting by distinguishing between:
+- `failed`: Test failed due to assertion error (test logic issue)
+- `invalid`: Test failed due to non-assertion error (infrastructure/setup issue)
+
+This change provides better insights into test failures and helps identify whether issues are related to test logic or infrastructure problems.
+
 # qase-robotframework 3.4.4
 
 ## What's new

--- a/qase-robotframework/changelog_new.md
+++ b/qase-robotframework/changelog_new.md
@@ -1,0 +1,18 @@
+# qase-robotframework 3.4.5
+
+## What's new
+
+- Improved test failure status handling
+- Enhanced error classification to distinguish assertion errors from other failures
+- Assertion errors (containing keywords like 'assert', 'AssertionError', 'expect', 'should', 'must', 'equal', 'not equal') now map to `failed` status
+- Non-assertion errors (setup failures, exceptions, etc.) now map to `invalid` status
+- Updated dependency on qase-python-commons to version 3.5.5
+
+## Migration Guide
+
+The listener now provides more accurate test result reporting by distinguishing between:
+- `failed`: Test failed due to assertion error (test logic issue)
+- `invalid`: Test failed due to non-assertion error (infrastructure/setup issue)
+
+This change provides better insights into test failures and helps identify whether issues are related to test logic or infrastructure problems.
+

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.4.4"
+version = "3.4.5"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -17,7 +17,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.3",
+    "qase-python-commons~=3.5.5",
     "filelock~=3.12.2",
 ]
 

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,21 @@
+# qase-tavern 1.1.4
+
+## What's new
+
+- Improved test failure status handling
+- Enhanced error classification to distinguish assertion errors from other failures
+- Assertion errors (AssertionError) now map to `failed` status
+- Non-assertion errors (setup failures, exceptions, etc.) now map to `invalid` status
+- Updated dependency on qase-python-commons to version 3.5.5
+
+## Migration Guide
+
+The plugin now provides more accurate test result reporting by distinguishing between:
+- `failed`: Test failed due to assertion error (test logic issue)
+- `invalid`: Test failed due to non-assertion error (infrastructure/setup issue)
+
+This change provides better insights into test failures and helps identify whether issues are related to test logic or infrastructure problems.
+
 # qase-tavern 1.1.3
 
 ## What's new

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "1.1.3"
+version = "1.1.4"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.4",
+    "qase-python-commons~=3.5.5",
     "pytest>=7,<7.3",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-tavern/src/qase/tavern/plugin.py
+++ b/qase-tavern/src/qase/tavern/plugin.py
@@ -35,7 +35,10 @@ class QasePytestPlugin:
     def pytest_runtest_makereport(self, item, call):
         if call.when == "call":
             if call.excinfo:
-                self.runtime.result.execution.status = "failed"
+                # Determine if it's an assertion error or other error
+                is_assertion_error = call.excinfo.typename == "AssertionError"
+                status = "failed" if is_assertion_error else "invalid"
+                self.runtime.result.execution.status = status
                 if hasattr(call.excinfo, "value"):
                     self.runtime.result.execution.stacktrace = '\n'.join(call.excinfo.value.args)
                     if hasattr(call.excinfo.value, "failures"):


### PR DESCRIPTION
- Updated version to 1.1.6 in pyproject.toml.
- Enhanced error classification to distinguish between assertion errors and other failures.
- Introduced `invalid` status for non-assertion errors, improving test result reporting.
- Updated dependency on qase-python-commons to version 3.5.5.
- Enhanced changelog to reflect new features and migration guide for better insights into test failures.