### PR TITLE
feat: release version 1.1.7 with support for external links in test runs

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,10 @@
+# qase-behave 1.1.7
+
+## What's new
+
+- Added support for updating external link for a test run.
+- Updated dependency on qase-python-commons to version 3.5.6.
+
 # qase-behave 1.1.6
 
 ## What's new

--- a/qase-behave/docs/CONFIGURATION.md
+++ b/qase-behave/docs/CONFIGURATION.md
@@ -30,6 +30,8 @@ and command line options override both other values.
 | Create test run using a test plan         | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `qase-testops-plan-id`          | None, don't use plans for the test run  | No       | Any integer                |
 | Complete test run after running tests     | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `qase-testops-run-complete`     | `True`                                  | No       | `True`, `False`            |
 | ID of the Qase test run to report results | `testops.run.id`           | `QASE_TESTOPS_RUN_ID`           | `qase-testops-run-id`           | None, create a new test run             | No       | Any integer                |
+| External link type for test run           | `testops.run.externalLink.type` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | `qase-testops-run-external-link-type` | None, don't add external link           | No       | `jiraCloud`, `jiraServer`   |
+| External link URL for test run            | `testops.run.externalLink.link` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_URL` | `qase-testops-run-external-link-url` | None, don't add external link           | No       | Any string (e.g., "PROJ-1234") |
 | Batch size for uploading test results     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `qase-testops-batch-size`       | 200                                     | No       | 1 to 2000                  |
 | Create defects in Qase                    | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `qase-testops-defect`           | `False`, don't create defects           | No       | `True`, `False`            |
 | Test run tags                             | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `qase-testops-run-tags`         | None, don't add any tags                | No       | Comma-separated list of tags |
@@ -67,7 +69,11 @@ and command line options override both other values.
       "title": "Regress run",
       "description": "Regress run description",
       "complete": true,
-      "tags": ["tag1", "tag2"]
+      "tags": ["tag1", "tag2"],
+      "externalLink": {
+        "type": "jiraCloud",
+        "link": "PROJ-1234"
+      }
     },
     "defect": false,
     "project": "<project_code>",

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.1.6"
+version = "1.1.7"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.5",
+    "qase-python-commons~=3.5.6",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/formatter.py
+++ b/qase-behave/src/qase/behave/formatter.py
@@ -129,6 +129,18 @@ class QaseFormatter(Formatter):
             cfg_mgr.config.testops.run.set_tags(
                 [tag.strip() for tag in userdata['qase-testops-run-tags'].split(',')])
 
+        if 'qase-testops-run-external-link-type' in userdata:
+            if not cfg_mgr.config.testops.run.external_link:
+                from qase.commons.models.external_link import ExternalLinkConfig
+                cfg_mgr.config.testops.run.external_link = ExternalLinkConfig()
+            cfg_mgr.config.testops.run.external_link.set_type(userdata['qase-testops-run-external-link-type'])
+
+        if 'qase-testops-run-external-link-url' in userdata:
+            if not cfg_mgr.config.testops.run.external_link:
+                from qase.commons.models.external_link import ExternalLinkConfig
+                cfg_mgr.config.testops.run.external_link = ExternalLinkConfig()
+            cfg_mgr.config.testops.run.external_link.set_link(userdata['qase-testops-run-external-link-url'])
+
         if 'qase-testops-plan-id' in userdata:
             cfg_mgr.config.testops.plan.set_id(
                 userdata['qase-testops-plan-id'])

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 6.3.10
+
+## What's new
+
+- Added support for updating external link for a test run.
+- Updated dependency on qase-python-commons to version 3.5.6.
+
 # qase-pytest 6.3.9
 
 ## What's new

--- a/qase-pytest/docs/CONFIGURATION.md
+++ b/qase-pytest/docs/CONFIGURATION.md
@@ -33,6 +33,8 @@ and command line options override both other values.
 | Batch size for uploading test results          | `testops.batch.size`                 | `QASE_TESTOPS_BATCH_SIZE`        | `--qase-testops-batch-size`        | 200                                     | No       | 1 to 2000                  |
 | Create defects in Qase                         | `testops.defect`                     | `QASE_TESTOPS_DEFECT`            | `--qase-testops-defect`            | `False`, don't create defects           | No       | `True`, `False`            |
 | Test run tags                                  | `testops.run.tags`                   | `QASE_TESTOPS_RUN_TAGS`          | `--qase-testops-run-tags`          | None, don't add any tags                | No       | Comma-separated list of tags |
+| External link type for test run                | `testops.run.externalLink.type`      | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | `--qase-testops-run-external-link-type` | None, don't add external link           | No       | `jiraCloud`, `jiraServer`   |
+| External link URL for test run                 | `testops.run.externalLink.link`      | `QASE_TESTOPS_RUN_EXTERNAL_LINK_URL` | `--qase-testops-run-external-link-url` | None, don't add external link           | No       | Any string (e.g., "PROJ-1234") |
 | Test run configurations                        | `testops.configurations.values`      | `QASE_TESTOPS_CONFIGURATIONS_VALUES` | `--qase-testops-configurations-values` | None, don't add any configurations      | No       | Format: "group1=value1,group2=value2" |
 | Create configurations if not exists            | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `--qase-testops-configurations-create-if-not-exists` | `False`, don't create configurations     | No       | `True`, `False`            |
 | Filter results by status                      | `testops.statusFilter`                | `QASE_TESTOPS_STATUS_FILTER`     | `--qase-testops-status-filter`     | None, don't filter any results          | No       | Comma-separated list of statuses |
@@ -76,7 +78,11 @@ and command line options override both other values.
       "title": "Regress run",
       "description": "Regress run description",
       "complete": true,
-      "tags": ["tag1", "tag2"]
+      "tags": ["tag1", "tag2"],
+      "externalLink": {
+        "type": "jiraCloud",
+        "link": "PROJ-1234"
+      }
     },
     "defect": false,
     "project": "<project_code>",

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.9"
+version = "6.3.10"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.5",
+    "qase-python-commons~=3.5.6",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -190,6 +190,18 @@ def setup_config_manager(config):
                 config_manager.config.testops.set_status_filter(
                     [status.strip() for status in config.option.__dict__[option].split(',')])
 
+            if option == "qase_testops_run_external_link_type" and config.option.__dict__[option] is not None:
+                if not config_manager.config.testops.run.external_link:
+                    from qase.commons.models.external_link import ExternalLinkConfig
+                    config_manager.config.testops.run.external_link = ExternalLinkConfig()
+                config_manager.config.testops.run.external_link.set_type(config.option.__dict__[option])
+
+            if option == "qase_testops_run_external_link_url" and config.option.__dict__[option] is not None:
+                if not config_manager.config.testops.run.external_link:
+                    from qase.commons.models.external_link import ExternalLinkConfig
+                    config_manager.config.testops.run.external_link = ExternalLinkConfig()
+                config_manager.config.testops.run.external_link.set_link(config.option.__dict__[option])
+
     return config_manager
 
 

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -127,6 +127,22 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-run-external-link-type",
+            dest="qase_testops_run_external_link_type",
+            help="External link type for test run: `jiraCloud` or `jiraServer`"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
+            "--qase-testops-run-external-link-url",
+            dest="qase_testops_run_external_link_url",
+            help="External link URL or identifier for test run"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-testops-batch-size",
             dest="qase_testops_batch_size",
             type="int",

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,10 @@
+# qase-robotframework 3.4.7
+
+## What's new
+
+- Added support for updating external link for a test run.
+- Updated dependency on qase-python-commons to version 3.5.6.
+
 # qase-robotframework 3.4.6
 
 ## What's new

--- a/qase-robotframework/docs/CONFIGURATION.md
+++ b/qase-robotframework/docs/CONFIGURATION.md
@@ -27,6 +27,8 @@ Environment variables override the values given in the config file.
 | Create test run using a test plan         | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | None, don't use plans for the test run  | No       | Any integer                |
 | Complete test run after running tests     | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `True`                                  | No       | `true`, `false`            |
 | ID of the Qase test run to report results | `testops.run.id`           | `QASE_TESTOPS_RUN_ID`           | None, create a new test run             | No       | Any integer                |
+| External link type for test run           | `testops.run.externalLink.type` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | None, don't add external link           | No       | `jiraCloud`, `jiraServer`   |
+| External link URL for test run            | `testops.run.externalLink.link` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_URL` | None, don't add external link           | No       | Any string (e.g., "PROJ-1234") |
 | Batch size for uploading test results     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | 200                                     | No       | 1 to 2000                  |
 | Create defects in Qase                    | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `False`, don't create defects           | No       | `True`, `False`            |
 | Test run tags                             | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | None, don't add any tags                | No       | Comma-separated list of tags |
@@ -64,7 +66,11 @@ Environment variables override the values given in the config file.
       "title": "Regress run",
       "description": "Regress run description",
       "complete": true,
-      "tags": ["tag1", "tag2"]
+      "tags": ["tag1", "tag2"],
+      "externalLink": {
+        "type": "jiraCloud",
+        "link": "PROJ-1234"
+      }
     },
     "defect": false,
     "project": "<project_code>",

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.4.6"
+version = "3.4.7"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -17,7 +17,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.5",
+    "qase-python-commons~=3.5.6",
     "filelock~=3.12.2",
 ]
 

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,10 @@
+# qase-tavern 1.1.5
+
+## What's new
+
+- Added support for updating external link for a test run.
+- Updated dependency on qase-python-commons to version 3.5.6.
+
 # qase-tavern 1.1.4
 
 ## What's new

--- a/qase-tavern/docs/CONFIGURATION.md
+++ b/qase-tavern/docs/CONFIGURATION.md
@@ -30,6 +30,8 @@ and command line options override both other values.
 | Create test run using a test plan         | `testops.plan.id`          | `QASE_TESTOPS_PLAN_ID`          | `--qase-testops-plan-id`          | None, don't use plans for the test run  | No       | Any integer                |
 | Complete test run after running tests     | `testops.run.complete`     | `QASE_TESTOPS_RUN_COMPLETE`     | `--qase-testops-run-complete`     | `True`                                  | No       | `true`, `false`            |
 | ID of the Qase test run to report results | `testops.run.id`           | `QASE_TESTOPS_RUN_ID`           | `--qase-testops-run-id`           | None, create a new test run             | No       | Any integer                |
+| External link type for test run           | `testops.run.externalLink.type` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_TYPE` | `--qase-testops-run-external-link-type` | None, don't add external link           | No       | `jiraCloud`, `jiraServer`   |
+| External link URL for test run            | `testops.run.externalLink.link` | `QASE_TESTOPS_RUN_EXTERNAL_LINK_URL` | `--qase-testops-run-external-link-url` | None, don't add external link           | No       | Any string (e.g., "PROJ-1234") |
 | Batch size for uploading test results     | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `--qase-testops-batch-size`       | 200                                     | No       | 1 to 2000                  |
 | Create defects in Qase                    | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `--qase-testops-defect`           | `False`, don't create defects           | No       | `True`, `False`            |
 | Tags for test run                         | `testops.run.tags`         | `QASE_TESTOPS_RUN_TAGS`         | `--qase-testops-run-tags`         | None                                    | No       | Comma-separated list of tags |
@@ -67,7 +69,11 @@ and command line options override both other values.
       "title": "Regress run",
       "description": "Regress run description",
       "complete": true,
-      "tags": ["tag1", "tag2"]
+      "tags": ["tag1", "tag2"],
+      "externalLink": {
+        "type": "jiraCloud",
+        "link": "PROJ-1234"
+      }
     },
     "defect": false,
     "project": "<project_code>",

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "1.1.4"
+version = "1.1.5"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "qase-python-commons~=3.5.5",
+    "qase-python-commons~=3.5.6",
     "pytest>=7,<7.3",
     "filelock~=3.12.2",
     "more_itertools",

--- a/qase-tavern/src/qase/tavern/conftest.py
+++ b/qase-tavern/src/qase/tavern/conftest.py
@@ -132,6 +132,18 @@ def setup_config_manager(config):
                 config_manager.config.testops.set_status_filter(
                     [status.strip() for status in config.option.__dict__[option].split(',')])
 
+            if option == "qase_testops_run_external_link_type" and config.option.__dict__[option] is not None:
+                if not config_manager.config.testops.run.external_link:
+                    from qase.commons.models.external_link import ExternalLinkConfig
+                    config_manager.config.testops.run.external_link = ExternalLinkConfig()
+                config_manager.config.testops.run.external_link.set_type(config.option.__dict__[option])
+
+            if option == "qase_testops_run_external_link_url" and config.option.__dict__[option] is not None:
+                if not config_manager.config.testops.run.external_link:
+                    from qase.commons.models.external_link import ExternalLinkConfig
+                    config_manager.config.testops.run.external_link = ExternalLinkConfig()
+                config_manager.config.testops.run.external_link.set_link(config.option.__dict__[option])
+
             if option == "qase_testops_defect" and config.option.__dict__[option] is not None:
                 config_manager.config.testops.set_defect(config.option.__dict__[option])
 

--- a/qase-tavern/src/qase/tavern/options.py
+++ b/qase-tavern/src/qase/tavern/options.py
@@ -119,6 +119,22 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-run-external-link-type",
+            dest="qase_testops_run_external_link_type",
+            help="External link type for test run: `jiraCloud` or `jiraServer`"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
+            "--qase-testops-run-external-link-url",
+            dest="qase_testops_run_external_link_url",
+            help="External link URL or identifier for test run"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-testops-batch-size",
             dest="qase_testops_batch_size",
             type="int",


### PR DESCRIPTION
- Updated version to 1.1.7 in pyproject.toml.
- Added support for updating external link type and URL for test runs.
- Updated dependency on qase-python-commons to version 3.5.6.
- Enhanced documentation to include new configuration options for external links.

This release improves integration with external issue tracking systems.