### PR TITLE
feat: release version 2.0.0 with support for Python 3.9 and above

### DIFF
--- a/qase-behave/README.md
+++ b/qase-behave/README.md
@@ -103,7 +103,7 @@ Configuration options are described in the
 
 We maintain the reporter on [LTS versions of Python](https://devguide.python.org/versions/).
 
-`python >= 3.7`
+`python >= 3.9`
 `behave >= 1.2.6`
 
 <!-- references -->

--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,10 @@
+# qase-behave 2.0.0
+
+## What's new
+
+- Unsupport Python 3.7 and 3.8. Support Python 3.9, 3.10, 3.11, 3.12, 3.13.
+- Updated the `qase-python-commons` dependency to the latest version.
+  
 # qase-behave 1.1.7
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "1.1.7"
+version = "2.0.0"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -20,16 +20,15 @@ classifiers = [
     'Topic :: Software Development :: Testing',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=3.5.6",
+    "qase-python-commons~=4.0.0",
     "behave>=1.2.6",
     "more_itertools",
 ]
@@ -49,8 +48,8 @@ testing = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-minversion = 3.7
-envlist = py{37,38,39,310,311}
+minversion = 3.9
+envlist = py{39,310,311,312,313}
 
 [testenv]
 deps =

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,10 @@
+# qase-pytest 7.0.0
+
+## What's new
+
+- Unsupport Python 3.7 and 3.8. Support Python 3.9, 3.10, 3.11, 3.12, 3.13.
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-pytest 6.3.10
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "6.3.10"
+version = "7.0.0"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -20,16 +20,15 @@ classifiers = [
     'Topic :: Software Development :: Testing',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=3.5.6",
+    "qase-python-commons~=4.0.0",
     "pytest>=7.4.4",
     "filelock~=3.12.2",
     "more_itertools",
@@ -52,8 +51,8 @@ testing = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-minversion = 3.7
-envlist = py{37,38,39,310,311}
+minversion = 3.9
+envlist = py{39,310,311,312,313}
 
 [testenv]
 deps =

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,10 +1,10 @@
-# qase-robotframework 3.4.7
+# qase-robotframework 4.0.0
 
 ## What's new
 
-- Added support for updating external link for a test run.
-- Updated dependency on qase-python-commons to version 3.5.6.
-
+- Unsupport Python 3.7 and 3.8. Support Python 3.9, 3.10, 3.11, 3.12, 3.13.
+- Updated the `qase-python-commons` dependency to the latest version.
+- 
 # qase-robotframework 3.4.6
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "3.4.7"
+version = "4.0.0"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -13,11 +13,18 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Robot Framework",
     "Programming Language :: Python",
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=3.5.6",
+    "qase-python-commons~=4.0.0",
     "filelock~=3.12.2",
 ]
 
@@ -30,8 +37,8 @@ testing = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-minversion = 3.7
-envlist = py{37,38,39,310,311}
+minversion = 3.9
+envlist = py{39,310,311,312,313}
 
 [testenv]
 deps =

--- a/qase-tavern/README.md
+++ b/qase-tavern/README.md
@@ -98,7 +98,7 @@ Configuration options are described in the
 
 We maintain the reporter on [LTS versions of Python](https://devguide.python.org/versions/).
 
-`python >= 3.7`
+`python >= 3.9`
 `tavern >= 2.11.0`
 
 <!-- references -->

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,10 @@
+# qase-tavern 2.0.0
+
+## What's new
+
+- Unsupport Python 3.7 and 3.8. Support Python 3.9, 3.10, 3.11, 3.12, 3.13.
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-tavern 1.1.5
 
 ## What's new

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "1.1.5"
+version = "2.0.0"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -20,16 +20,15 @@ classifiers = [
     'Topic :: Software Development :: Testing',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=3.5.6",
+    "qase-python-commons~=4.0.0",
     "pytest>=7,<7.3",
     "filelock~=3.12.2",
     "more_itertools",
@@ -52,8 +51,8 @@ testing = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-minversion = 3.7
-envlist = py{37,38,39,310,311}
+minversion = 3.9
+envlist = py{39,310,311,312,313}
 
 [testenv]
 deps =


### PR DESCRIPTION
- Updated version to 2.0.0 in pyproject.toml for all components.
- Removed support for Python 3.7 and 3.8, now supporting Python 3.9, 3.10, 3.11, 3.12, and 3.13.
- Updated the `qase-python-commons` dependency to the latest version across all projects.
- Enhanced documentation to reflect the new minimum Python version requirements.

This release improves compatibility with newer Python versions and updates dependencies for better performance.