### PR TITLE
chore: update versions and fix filelock dependency compatibility

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 7.0.4
+
+## Bug fixes
+
+- Fixed filelock dependency compatibility issue with modern tox versions. Changed filelock requirement from `~=3.12.2` to `>=3.12.2` to support newer versions required by tox>=4.26.0 and tox-uv. This resolves dependency conflicts when using modern development tools.
+
 # qase-pytest 7.0.3
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "7.0.3"
+version = "7.0.4"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "qase-python-commons~=4.1.0",
     "pytest>=7.4.4",
-    "filelock~=3.12.2",
+    "filelock>=3.12.2",
     "more_itertools",
 ]
 

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,9 @@
+# qase-robotframework 4.0.3
+
+## Bug fixes
+
+- Fixed filelock dependency compatibility issue with modern tox versions. Changed filelock requirement from `~=3.12.2` to `>=3.12.2` to support newer versions required by tox>=4.26.0 and tox-uv. This resolves dependency conflicts when using modern development tools.
+
 # qase-robotframework 4.0.2
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "4.0.2"
+version = "4.0.3"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -25,7 +25,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-rob
 requires-python = ">=3.9"
 dependencies = [
     "qase-python-commons~=4.1.0",
-    "filelock~=3.12.2",
+    "filelock>=3.12.2",
 ]
 
 [project.optional-dependencies]

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,9 @@
+# qase-tavern 2.0.3
+
+## Bug fixes
+
+- Fixed filelock dependency compatibility issue with modern tox versions. Changed filelock requirement from `~=3.12.2` to `>=3.12.2` to support newer versions required by tox>=4.26.0 and tox-uv. This resolves dependency conflicts when using modern development tools.
+
 # qase-tavern 2.0.2
 
 ## What's new

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "2.0.2"
+version = "2.0.3"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     "qase-python-commons~=4.1.0",
     "pytest>=7,<7.3",
-    "filelock~=3.12.2",
+    "filelock>=3.12.2",
     "more_itertools",
 ]
 


### PR DESCRIPTION
- Updated version to 7.0.4 for qase-pytest, 4.0.3 for qase-robotframework, and 2.0.3 for qase-tavern in pyproject.toml.
- Modified filelock dependency requirement from `~=3.12.2` to `>=3.12.2` to ensure compatibility with modern tox versions, resolving potential dependency conflicts.
- Updated changelogs to reflect the new versions and changes.

This release enhances compatibility with modern development tools across all components.

#411