### PR TITLE
feat: release version updates with automatic public report link support

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,9 @@
+# qase-behave 2.0.3
+
+## What's new
+
+- Added support for automatic public report link generation.
+
 # qase-behave 2.0.2
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "2.0.2"
+version = "2.0.3"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.0",
+    "qase-python-commons~=4.1.1",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/formatter.py
+++ b/qase-behave/src/qase/behave/formatter.py
@@ -176,6 +176,10 @@ class QaseFormatter(Formatter):
             cfg_mgr.config.testops.set_status_filter(
                 [status.strip() for status in userdata['qase-testops-status-filter'].split(',')])
 
+        if 'qase-testops-show-public-report-link' in userdata:
+            cfg_mgr.config.testops.set_show_public_report_link(
+                userdata['qase-testops-show-public-report-link'])
+
         if 'qase-status-mapping' in userdata:
             # Parse status mapping from userdata
             # Format: "source1=target1,source2=target2"

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 7.0.5
+
+## What's new
+
+- Added support for automatic public report link generation.
+
 # qase-pytest 7.0.4
 
 ## Bug fixes

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "7.0.4"
+version = "7.0.5"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.0",
+    "qase-python-commons~=4.1.1",
     "pytest>=7.4.4",
     "filelock>=3.12.2",
     "more_itertools",

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -190,6 +190,10 @@ def setup_config_manager(config):
                 config_manager.config.testops.set_status_filter(
                     [status.strip() for status in config.option.__dict__[option].split(',')])
 
+            if option == "qase_testops_show_public_report_link" and config.option.__dict__[option] is not None:
+                config_manager.config.testops.set_show_public_report_link(
+                    config.option.__dict__[option])
+
             if option == "qase_status_mapping" and config.option.__dict__[option] is not None:
                 # Parse status mapping from CLI parameter
                 # Format: "source1=target1,source2=target2"

--- a/qase-pytest/src/qase/pytest/options.py
+++ b/qase-pytest/src/qase/pytest/options.py
@@ -186,6 +186,15 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-show-public-report-link",
+            dest="qase_testops_show_public_report_link",
+            type="bool",
+            help="Enable automatic generation of public report link after test run completion"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-status-mapping",
             dest="qase_status_mapping",
             help="Map test result statuses. Format: 'invalid=failed,skipped=passed'"

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,9 @@
+# qase-tavern 2.0.4
+
+## What's new
+
+- Added support for automatic public report link generation.
+
 # qase-tavern 2.0.3
 
 ## Bug fixes

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "2.0.3"
+version = "2.0.4"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.0",
+    "qase-python-commons~=4.1.1",
     "pytest>=7,<7.3",
     "filelock>=3.12.2",
     "more_itertools",

--- a/qase-tavern/src/qase/tavern/conftest.py
+++ b/qase-tavern/src/qase/tavern/conftest.py
@@ -132,6 +132,10 @@ def setup_config_manager(config):
                 config_manager.config.testops.set_status_filter(
                     [status.strip() for status in config.option.__dict__[option].split(',')])
 
+            if option == "qase_testops_show_public_report_link" and config.option.__dict__[option] is not None:
+                config_manager.config.testops.set_show_public_report_link(
+                    config.option.__dict__[option])
+
             if option == "qase_status_mapping" and config.option.__dict__[option] is not None:
                 # Parse status mapping from CLI parameter
                 # Format: "source1=target1,source2=target2"

--- a/qase-tavern/src/qase/tavern/options.py
+++ b/qase-tavern/src/qase/tavern/options.py
@@ -186,6 +186,15 @@ class QasePytestOptions:
         QasePytestOptions.add_option(
             parser,
             group,
+            "--qase-testops-show-public-report-link",
+            dest="qase_testops_show_public_report_link",
+            type="bool",
+            help="Enable automatic generation of public report link after test run completion"
+        )
+
+        QasePytestOptions.add_option(
+            parser,
+            group,
             "--qase-status-mapping",
             dest="qase_status_mapping",
             help="Map test result statuses. Format: 'invalid=failed,skipped=passed'"


### PR DESCRIPTION
- Updated version to 2.0.3 for qase-behave, 7.0.5 for qase-pytest, and 2.0.4 for qase-tavern in pyproject.toml.
- Added functionality to enable automatic public report link generation for test runs across all components.
- Updated changelogs to reflect the new versions and changes.

This release enhances reporting capabilities by allowing users to generate public links for test run reports.