### PR TITLE
feat: release version 2.0.4 with time mocking compatibility improvements

### DIFF
--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,10 @@
+# qase-behave 2.0.4
+
+## What's new
+
+- Fixed compatibility with time mocking libraries like `freezegun`. Step timestamps now use real system time instead of mocked time. This prevents "Data is invalid" errors from Qase API. Resolves [#415](https://github.com/qase-tms/qase-python/issues/415).
+- Updated dependency on qase-python-commons to version 4.1.2
+
 # qase-behave 2.0.3
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "2.0.3"
+version = "2.0.4"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.1",
+    "qase-python-commons~=4.1.2",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -110,7 +110,7 @@ def parse_step(step: Step) -> QaseStep:
         data=StepGherkinData(keyword=step.keyword, name=step.name, line=step.line)
     )
 
-    current_time = time.time()
+    current_time = QaseUtils.get_real_time()
     
     # Map behave status to qase status
     status_mapping = {


### PR DESCRIPTION
- Updated version to 2.0.4 in pyproject.toml.
- Fixed compatibility with time mocking libraries by using real system time for step timestamps, preventing "Data is invalid" errors from Qase API. Resolves #415.
- Updated dependency on qase-python-commons to version 4.1.2.
- Updated changelog to reflect the new version and changes.

This release enhances compatibility with time mocking libraries, ensuring accurate timestamp reporting.