### PR TITLE
feat: release version 4.0.4 with Gherkin step input data support

### DIFF
--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,9 @@
+# qase-robotframework 4.0.4
+
+## What's new
+
+- Added support input data for Gherkin steps.
+
 # qase-robotframework 4.0.3
 
 ## Bug fixes

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "4.0.3"
+version = "4.0.4"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -24,7 +24,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.0",
+    "qase-python-commons~=4.1.4",
     "filelock>=3.12.2",
 ]
 

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -39,7 +39,7 @@ class Listener:
         self.tests = {}
         self.pabot_index = None
         self.last_level_flag = None
-        
+
         # Use centralized logger from config
         self.logger = config.logger
 
@@ -84,14 +84,15 @@ class Listener:
 
         if test_metadata.params:
             # Get argument names from the implementation
-            args_names = implementation.args.argument_names if hasattr(implementation.args, 'argument_names') else []
+            args_names = implementation.args.argument_names if hasattr(
+                implementation.args, 'argument_names') else []
             args_values = result.args if hasattr(result, 'args') else []
             params: dict = {}
             for param in test_metadata.params:
                 if param in args_names:
                     params[param] = args_values[args_names.index(param)]
             self.runtime.result.params = params
-        
+
         if test_metadata.fields:
             for key, value in test_metadata.fields.items():
                 self.runtime.result.add_field(Field(key, value))
@@ -109,15 +110,17 @@ class Listener:
             self.runtime.result.testops_ids = test_metadata.qase_ids
 
         self.runtime.result.execution.complete()
-        
+
         # Determine if it's an assertion error or other error
         status = STATUSES[result.status]
         if status == "failed" and hasattr(result, 'message'):
             # Check if the error message contains assertion-related keywords
-            assertion_keywords = ['assert', 'AssertionError', 'expect', 'should', 'must', 'equal', 'not equal']
-            is_assertion_error = any(keyword in result.message for keyword in assertion_keywords)
+            assertion_keywords = ['assert', 'AssertionError',
+                                  'expect', 'should', 'must', 'equal', 'not equal']
+            is_assertion_error = any(
+                keyword in result.message for keyword in assertion_keywords)
             status = "failed" if is_assertion_error else "invalid"
-        
+
         self.runtime.result.execution.set_status(status)
         if hasattr(result, 'message'):
             self.runtime.result.execution.stacktrace = result.message
@@ -210,10 +213,15 @@ class Listener:
             else:
                 step_name = result.body[i].name
 
+            data = None
+            if hasattr(result.body[i], "args") and result.body[i].args:
+                data = ' '.join(result.body[i].args)
+
             step = Step(
                 step_type=StepType.GHERKIN,
                 id=str(uuid.uuid4()),
-                data=StepGherkinData(keyword=step_name, name=step_name, line=0)
+                data=StepGherkinData(
+                    keyword=step_name, name=step_name, line=0, data=data)
             )
 
             # Determine step status


### PR DESCRIPTION
- Updated version to 4.0.4 in pyproject.toml.
- Added support for input data in Gherkin steps in the listener.
- Updated changelog to reflect the new version and changes.

This release enhances the functionality of Gherkin steps by allowing the inclusion of input data, improving test case definitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds input data support for Gherkin steps in the Robot Framework listener and releases 4.0.4 with an updated commons dependency.
> 
> - **Robot Framework Listener (`src/qase/robotframework/listener.py`)**:
>   - Capture step arguments and include them as `data` in `StepGherkinData` for Gherkin steps.
> - **Release/Versioning**:
>   - Bump package version to `4.0.4` in `pyproject.toml`.
>   - Update dependency `qase-python-commons` to `~4.1.4`.
> - **Changelog**:
>   - Add `4.0.4` entry noting Gherkin step input data support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca0bde6952a823f5e46b76a99bf8918bb064993e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->