### PR TITLE
feat(qase-pytest: commons): fix str env var comparing to int

### DIFF
--- a/qase-python-commons/src/qase/commons/models/config/batch.py
+++ b/qase-python-commons/src/qase/commons/models/config/batch.py
@@ -19,5 +19,4 @@ class BatchConfig(BaseModel):
             if size_int > 2000 or size_int == 0:
                 self.size = size_int
         except ValueError:
-            raise ValueError("Batch size should be greater than 0 and less than 2000")
-
+            raise ValueError("Batch size should be numeric value")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `BatchConfig.set_size` now accepts strings (trimmed and converted to int) and `size` is typed as non-optional int defaulting to 200.
> 
> - **Commons / Config**:
>   - **`BatchConfig`** (`qase-python-commons/src/qase/commons/models/config/batch.py`):
>     - `size` annotated as `int` (non-optional), initialized to `200` in `__init__`.
>     - `set_size` now accepts `Union[int, str]`; trims and converts string inputs to `int`.
>     - Validation logic updated: assigns `size` when `size_int > 2000` or `size_int == 0`; raises `ValueError("Batch size should be numeric value")` for non-numeric input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4019d560a17e1266079bc165c8ae1bd98f45deb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



fixes https://github.com/qase-tms/qase-python/issues/422
