### PR TITLE
chore: update qase dependencies in example requirements files

### DIFF
--- a/examples/behave/requirements.txt
+++ b/examples/behave/requirements.txt
@@ -1,2 +1,2 @@
 behave>=1.2.6
-qase-behave>=1.0.0
+qase-behave>=2.0.4

--- a/examples/pytest/requirements.txt
+++ b/examples/pytest/requirements.txt
@@ -1,8 +1,5 @@
 pytest==8.1.1
-qase-pytest==6.0.0
-qase-python-commons==3.0.2
-qase-api-client==1.0.1
-qase-api-v2-client==1.0.0
+qase-pytest==7.0.6
 psycopg2-binary>=2.9.0
 pymysql>=1.0.0
 pymongo>=4.0.0

--- a/examples/robot/requirements.txt
+++ b/examples/robot/requirements.txt
@@ -1,3 +1,3 @@
 robotframework==7.1.1
-qase-robotframework==3.2.2
+qase-robotframework==4.0.6
 robotframework-pabot==2.18.0

--- a/examples/tavern/requirements.txt
+++ b/examples/tavern/requirements.txt
@@ -1,2 +1,2 @@
 tavern==2.11.0
-qase-tavern~=1.0.0
+qase-tavern~=2.0.4


### PR DESCRIPTION
- Updated qase-behave to version 2.0.4 in behave requirements.
- Updated qase-pytest to version 7.0.6 and removed outdated dependencies in pytest requirements.
- Updated qase-robotframework to version 4.0.6 in robot requirements.
- Updated qase-tavern to version 2.0.4 in tavern requirements.

These updates ensure compatibility with the latest versions of the Qase packages.