### PR TITLE
feat: release version 7.0.7 with reporter disablement in collect mode

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 7.0.7
+
+## What's new
+
+- Disable reporter for collect mode.
+
 # qase-pytest 7.0.6
 
 - Fixed issue with running tests in AWS Lambda.

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "7.0.6"
+version = "7.0.7"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/conftest.py
+++ b/qase-pytest/src/qase/pytest/conftest.py
@@ -18,6 +18,10 @@ def pytest_configure(config):
         "qase_parametrize_ignore: mark test to ignore parameters in Qase reports"
     )
 
+    # Skip plugin registration if pytest is running in collect-only mode
+    if config.option.collectonly:
+        return
+
     config_manager = setup_config_manager(config)
 
     QasePytestPluginSingleton.init(reporter=QaseCoreReporter(


### PR DESCRIPTION
- Updated version to 7.0.7 in pyproject.toml.
- Added a new feature to disable the reporter when pytest is running in collect-only mode.
- Updated changelog to reflect the new version and changes.

This release improves the functionality of the plugin by preventing unnecessary reporting during test collection.