### PR TITLE
feat: release version 4.1.9 with version string cleanup

### DIFF
--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "4.1.8"
+version = "4.1.9"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -72,7 +72,7 @@ class ApiV2Client(ApiV1Client):
                 x_client_parts.append(f"reporter={reporter_name}")
                 reporter_version = host_data.get('reporter', '')
                 if reporter_version:
-                    x_client_parts.append(f"reporter_version=v{reporter_version}")
+                    x_client_parts.append(f"reporter_version={reporter_version}")
             
             if framework:
                 x_client_parts.append(f"framework={framework}")
@@ -82,15 +82,15 @@ class ApiV2Client(ApiV1Client):
             
             client_v1_version = host_data.get('apiClientV1', '')
             if client_v1_version:
-                x_client_parts.append(f"client_version_v1=v{client_v1_version}")
+                x_client_parts.append(f"client_version_v1={client_v1_version}")
             
             client_v2_version = host_data.get('apiClientV2', '')
             if client_v2_version:
-                x_client_parts.append(f"client_version_v2=v{client_v2_version}")
+                x_client_parts.append(f"client_version_v2={client_v2_version}")
             
             core_version = host_data.get('commons', '')
             if core_version:
-                x_client_parts.append(f"core_version=v{core_version}")
+                x_client_parts.append(f"core_version={core_version}")
             
             x_client = ";".join(x_client_parts)
             


### PR DESCRIPTION
- Updated version to 4.1.9 in pyproject.toml.
- Removed 'v' prefix from version strings in ApiV2Client for cleaner output.
- Ensured consistent formatting of version information in host data retrieval.

This release enhances the clarity of version information in API responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to 4.1.9 and removes the 'v' prefix from X-Client version fields in ApiV2Client.
> 
> - **Versioning**:
>   - Bump `qase-python-commons` to `4.1.9` in `pyproject.toml`.
> - **Client headers** (`src/qase/commons/client/api_v2_client.py`):
>   - Normalize `X-Client` header values by removing `v` prefix from `reporter_version`, `client_version_v1`, `client_version_v2`, and `core_version`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db595c4bd9f57d7220da55a27c952ffaa676bd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->