### PR TITLE
feat: release version 2.0.3 with urllib3 dependency update

### DIFF
--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "2.0.2"
+version = "2.0.3"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.9"
 dependencies = [
-    "urllib3 >= 2.5.0",
+    "urllib3 >= 2.5.0, < 2.7.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-client/requirements.txt
+++ b/qase-api-client/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.5.0
+urllib3 >= 2.5.0, < 2.7.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 lazy-imports >= 1, < 2

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "2.0.2"
+version = "2.0.3"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.9"
 dependencies = [
-    "urllib3 >= 2.5.0",
+    "urllib3 >= 2.5.0, < 2.7.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-v2-client/requirements.txt
+++ b/qase-api-v2-client/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.5.0
+urllib3 >= 2.5.0, < 2.7.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 lazy-imports >= 1, < 2


### PR DESCRIPTION
- Updated version to 2.0.3 in pyproject.toml for both qase-api-client and qase-api-v2-client.
- Changed urllib3 dependency from ">= 2.5.0" to "< 2.7.0" in requirements files to ensure compatibility.

This release addresses compatibility issues with the urllib3 library, enhancing stability across the API clients.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps both Python clients to 2.0.3 and restricts urllib3 to >=2.5.0,<2.7.0 in pyproject and requirements.
> 
> - **Packaging**:
>   - **`qase-api-client`**:
>     - Bump `version` to `2.0.3` in `qase-api-client/pyproject.toml`.
>     - Constrain `urllib3` to `>= 2.5.0, < 2.7.0` in `pyproject.toml` and `requirements.txt`.
>   - **`qase-api-v2-client`**:
>     - Bump `version` to `2.0.3` in `qase-api-v2-client/pyproject.toml`.
>     - Constrain `urllib3` to `>= 2.5.0, < 2.7.0` in `pyproject.toml` and `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fea04e8a844545017d06ed8b30b37530cd74351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->