### PR TITLE
feat: release updates for Qase plugins with dependency upgrades

### DIFF
--- a/examples/behave/requirements.txt
+++ b/examples/behave/requirements.txt
@@ -1,2 +1,2 @@
 behave>=1.2.6
-qase-behave>=2.0.4
+qase-behave>=2.0.5

--- a/examples/pytest/requirements.txt
+++ b/examples/pytest/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.1.1
-qase-pytest==7.0.6
+qase-pytest==7.0.8
 psycopg2-binary>=2.9.0
 pymysql>=1.0.0
 pymongo>=4.0.0

--- a/examples/robot/requirements.txt
+++ b/examples/robot/requirements.txt
@@ -1,3 +1,3 @@
 robotframework==7.1.1
-qase-robotframework==4.0.6
+qase-robotframework==4.0.8
 robotframework-pabot==2.18.0

--- a/examples/tavern/requirements.txt
+++ b/examples/tavern/requirements.txt
@@ -1,2 +1,2 @@
 tavern==2.11.0
-qase-tavern~=2.0.4
+qase-tavern~=2.0.5

--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,9 @@
+# qase-behave 2.0.5
+
+## What's new
+
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-behave 2.0.4
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "2.0.4"
+version = "2.0.5"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.2",
+    "qase-python-commons~=4.1.10",
     "behave>=1.2.6",
     "more_itertools",
 ]

--- a/qase-behave/requirements.txt
+++ b/qase-behave/requirements.txt
@@ -1,4 +1,4 @@
 attrs==23.2.0
 behave>=1.2.6
-qase-python-commons~=3.5.1
+qase-python-commons~=4.1.10
 pytest>=7.0.0

--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,9 @@
+# qase-pytest 7.0.8
+
+## What's new
+
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-pytest 7.0.7
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "7.0.7"
+version = "7.0.8"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.1",
+    "qase-python-commons~=4.1.10",
     "pytest>=7.4.4",
     "filelock>=3.12.2",
     "more_itertools",

--- a/qase-pytest/requirements.txt
+++ b/qase-pytest/requirements.txt
@@ -1,4 +1,4 @@
 attrs==23.2.0
 pytest>=8.0.0
 filelock~=3.13.1
-qase-python-commons~=3.5.0
+qase-python-commons~=4.1.10

--- a/qase-robotframework/changelog.md
+++ b/qase-robotframework/changelog.md
@@ -1,3 +1,9 @@
+# qase-robotframework 4.0.8
+
+## What's new
+
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-robotframework 4.0.7
 
 ## What's new

--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "4.0.7"
+version = "4.0.8"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -24,7 +24,7 @@ classifiers = [
 urls = {"Homepage" = "https://github.com/qase-tms/qase-python/tree/main/qase-robotframework"}
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.4",
+    "qase-python-commons~=4.1.10",
     "filelock>=3.12.2",
 ]
 

--- a/qase-robotframework/requirements.txt
+++ b/qase-robotframework/requirements.txt
@@ -1,2 +1,2 @@
-qase-python-commons~=3.5.0
+qase-python-commons~=4.1.10
 robotframework~=7.1

--- a/qase-tavern/changelog.md
+++ b/qase-tavern/changelog.md
@@ -1,3 +1,9 @@
+# qase-tavern 2.0.5
+
+## What's new
+
+- Updated the `qase-python-commons` dependency to the latest version.
+
 # qase-tavern 2.0.4
 
 ## What's new

--- a/qase-tavern/pyproject.toml
+++ b/qase-tavern/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-tavern"
-version = "2.0.4"
+version = "2.0.5"
 description = "Qase Tavern Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "tavern", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qase-python-commons~=4.1.1",
+    "qase-python-commons~=4.1.10",
     "pytest>=7,<7.3",
     "filelock>=3.12.2",
     "more_itertools",

--- a/qase-tavern/requirements.txt
+++ b/qase-tavern/requirements.txt
@@ -1,4 +1,4 @@
 attrs==23.2.0
 pytest>=7,<7.3
 filelock~=3.13.1
-qase-python-commons~=3.5.0
+qase-python-commons~=4.1.10


### PR DESCRIPTION
- Updated qase-behave to version 2.0.5, including an upgrade to `qase-python-commons` dependency.
- Updated qase-pytest to version 7.0.8, with a similar upgrade to `qase-python-commons`.
- Updated qase-robotframework to version 4.0.8, reflecting the latest `qase-python-commons` version.
- Updated qase-tavern to version 2.0.5, also upgrading the `qase-python-commons` dependency.

These updates enhance compatibility and functionality across all Qase plugins.