### PR TITLE
chore: update GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -50,6 +50,8 @@ jobs:
           tox
   build-n-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: test
     strategy:
       max-parallel: 1


### PR DESCRIPTION
- Added write permissions for contents in the build-n-publish job of the Python package workflow.

This change ensures that the workflow has the necessary permissions to publish artifacts effectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - Adds `permissions: contents: write` to the `build-n-publish` job in `.github/workflows/pythonpackage.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2feff6b0f909a3d4e0727b5d077fd3ab6a02dca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->