### PR TITLE
feat: release version 5.0.0 with multi-project support

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@5.0.0
+
+## What's new
+
+- Added support for multi-project reporting. You can now send test results to multiple Qase projects simultaneously.
+
 # qase-python-commons@4.1.10
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "4.1.10"
+version = "5.0.0"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -127,10 +127,12 @@ class ApiV2Client(ApiV1Client):
     def send_results(self, project_code: str, run_id: str, results: []) -> None:
         api_results = ResultsApi(self.client_v2)
         results_to_send = [self._prepare_result(project_code, result) for result in results]
-        self.logger.log_debug(f"Sending results for run {run_id}: {results_to_send}")
-        api_results.create_results_v2(project_code, run_id,
+        # Convert run_id to int as API expects StrictInt
+        run_id_int = int(run_id) if isinstance(run_id, str) else run_id
+        self.logger.log_debug(f"Sending results for run {run_id_int}: {results_to_send}")
+        api_results.create_results_v2(project_code, run_id_int,
                                       create_results_request_v2=CreateResultsRequestV2(results=results_to_send))
-        self.logger.log_debug(f"Results for run {run_id} sent successfully")
+        self.logger.log_debug(f"Results for run {run_id_int} sent successfully")
 
     def _prepare_result(self, project_code: str, result: Result) -> ResultCreate:
         attached = []

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -33,6 +33,17 @@ class ConfigManager:
             if self.config.testops.project is None:
                 errors.append("Testops project is not set")
 
+        if self.config.mode is Mode.testops_multi or self.config.fallback is Mode.testops_multi:
+            if self.config.testops.api.token is None:
+                errors.append("Testops token is not set")
+
+            if not self.config.testops_multi.projects or len(self.config.testops_multi.projects) == 0:
+                errors.append("Testops multi: at least one project must be configured")
+
+            for project in self.config.testops_multi.projects:
+                if not project.code:
+                    errors.append(f"Testops multi: project code is required for all projects")
+
         if len(errors) > 0:
             self.logger.log("Config validation failed", "error")
             for error in errors:
@@ -173,6 +184,9 @@ class ConfigManager:
                             self.config.testops.set_show_public_report_link(
                                 testops.get("showPublicReportLink")
                             )
+
+                    if config.get("testops_multi"):
+                        self.config.set_testops_multi(config.get("testops_multi"))
 
                     if config.get("report"):
                         report = config.get("report")

--- a/qase-python-commons/src/qase/commons/models/config/qaseconfig.py
+++ b/qase-python-commons/src/qase/commons/models/config/qaseconfig.py
@@ -3,13 +3,14 @@ from typing import List, Dict, Optional
 
 from .framework import Framework
 from .report import ReportConfig
-from .testops import TestopsConfig
+from .testops import TestopsConfig, TestopsMultiConfig
 from ..basemodel import BaseModel
 from ... import QaseUtils
 
 
 class Mode(Enum):
     testops = "testops"
+    testops_multi = "testops_multi"
     report = "report"
     off = "off"
 
@@ -47,6 +48,7 @@ class QaseConfig(BaseModel):
     debug: bool = None
     execution_plan: ExecutionPlan = None
     testops: TestopsConfig = None
+    testops_multi: TestopsMultiConfig = None
     report: ReportConfig = None
     profilers: list = None
     framework: Framework = None
@@ -59,6 +61,7 @@ class QaseConfig(BaseModel):
         self.fallback = Mode.off
         self.debug = False
         self.testops = TestopsConfig()
+        self.testops_multi = TestopsMultiConfig()
         self.report = ReportConfig()
         self.execution_plan = ExecutionPlan()
         self.framework = Framework()
@@ -98,3 +101,24 @@ class QaseConfig(BaseModel):
             self.logging.set_console(QaseUtils.parse_bool(logging_config.get("console")))
         if logging_config.get("file") is not None:
             self.logging.set_file(QaseUtils.parse_bool(logging_config.get("file")))
+
+    def set_testops_multi(self, testops_multi_config: dict):
+        """Set testops multi configuration from dictionary"""
+        if testops_multi_config:
+            if 'default_project' in testops_multi_config:
+                self.testops_multi.set_default_project(testops_multi_config['default_project'])
+            if 'projects' in testops_multi_config:
+                from .testops import ProjectConfig
+                projects = []
+                for project_data in testops_multi_config['projects']:
+                    project = ProjectConfig()
+                    if 'code' in project_data:
+                        project.set_code(project_data['code'])
+                    if 'run' in project_data:
+                        project.set_run(project_data['run'])
+                    if 'plan' in project_data:
+                        project.set_plan(project_data['plan'])
+                    if 'environment' in project_data:
+                        project.set_environment(project_data['environment'])
+                    projects.append(project)
+                self.testops_multi.set_projects(projects)

--- a/qase-python-commons/src/qase/commons/models/config/testops.py
+++ b/qase-python-commons/src/qase/commons/models/config/testops.py
@@ -4,7 +4,7 @@ from .plan import PlanConfig
 from .run import RunConfig
 from ..basemodel import BaseModel
 from ... import QaseUtils
-from typing import List
+from typing import List, Optional
 
 
 class ConfigurationValue(BaseModel):
@@ -72,3 +72,60 @@ class TestopsConfig(BaseModel):
 
     def set_show_public_report_link(self, show_public_report_link):
         self.show_public_report_link = QaseUtils.parse_bool(show_public_report_link)
+
+
+class ProjectConfig(BaseModel):
+    code: str = None
+    run: RunConfig = None
+    plan: PlanConfig = None
+    environment: Optional[str] = None
+
+    def __init__(self):
+        self.run = RunConfig()
+        self.plan = PlanConfig()
+        self.environment = None
+
+    def set_code(self, code: str):
+        self.code = code
+
+    def set_environment(self, environment: str):
+        self.environment = environment
+
+    def set_run(self, run_config: dict):
+        """Set run configuration from dictionary"""
+        if run_config:
+            if 'title' in run_config:
+                self.run.set_title(run_config['title'])
+            if 'description' in run_config:
+                self.run.set_description(run_config['description'])
+            if 'complete' in run_config:
+                self.run.set_complete(run_config['complete'])
+            if 'id' in run_config:
+                self.run.set_id(run_config['id'])
+            if 'tags' in run_config:
+                self.run.set_tags(run_config['tags'])
+            if 'externalLink' in run_config:
+                self.run.set_external_link(run_config['externalLink'])
+
+    def set_plan(self, plan_config: dict):
+        """Set plan configuration from dictionary"""
+        if plan_config and 'id' in plan_config:
+            self.plan.set_id(plan_config['id'])
+
+
+class TestopsMultiConfig(BaseModel):
+    default_project: Optional[str] = None
+    projects: List[ProjectConfig] = None
+
+    def __init__(self):
+        self.projects = []
+        self.default_project = None
+
+    def set_default_project(self, default_project: str):
+        self.default_project = default_project
+
+    def set_projects(self, projects: List[ProjectConfig]):
+        self.projects = projects
+
+    def add_project(self, project: ProjectConfig):
+        self.projects.append(project)

--- a/qase-python-commons/src/qase/commons/models/result.py
+++ b/qase-python-commons/src/qase/commons/models/result.py
@@ -76,6 +76,7 @@ class Result(BaseModel):
         self.title: str = title
         self.signature: str = signature
         self.testops_ids: Optional[List[int]] = None
+        self.testops_project_mapping: Optional[Dict[str, List[int]]] = None
         self.execution: Type[Execution] = Execution()
         self.fields: Dict[Type[Field]] = {}
         self.attachments: List[Attachment] = []
@@ -123,6 +124,46 @@ class Result(BaseModel):
 
     def get_testops_ids(self) -> Optional[List[int]]:
         return self.testops_ids
+
+    def set_testops_project_mapping(self, project_code: str, testops_ids: List[int]) -> None:
+        """
+        Set testops IDs for a specific project.
+        
+        :param project_code: Code of the project
+        :param testops_ids: List of test case IDs for this project
+        """
+        if self.testops_project_mapping is None:
+            self.testops_project_mapping = {}
+        self.testops_project_mapping[project_code] = testops_ids
+
+    def get_testops_project_mapping(self) -> Optional[Dict[str, List[int]]]:
+        """
+        Get the complete project mapping.
+        
+        :return: Dictionary mapping project codes to lists of test case IDs
+        """
+        return self.testops_project_mapping
+
+    def get_testops_ids_for_project(self, project_code: str) -> Optional[List[int]]:
+        """
+        Get testops IDs for a specific project.
+        
+        :param project_code: Code of the project
+        :return: List of test case IDs for the project, or None if not found
+        """
+        if self.testops_project_mapping is None:
+            return None
+        return self.testops_project_mapping.get(project_code)
+
+    def get_projects(self) -> List[str]:
+        """
+        Get list of all project codes from the mapping.
+        
+        :return: List of project codes
+        """
+        if self.testops_project_mapping is None:
+            return []
+        return list(self.testops_project_mapping.keys())
 
     def get_duration(self) -> int:
         return self.execution.duration

--- a/qase-python-commons/src/qase/commons/reporters/__init__.py
+++ b/qase-python-commons/src/qase/commons/reporters/__init__.py
@@ -1,9 +1,11 @@
 from .testops import QaseTestOps
+from .testops_multi import QaseTestOpsMulti
 from .report import QaseReport
 from .core import QaseCoreReporter
 
 __all__ = [
     QaseTestOps,
+    QaseTestOpsMulti,
     QaseReport,
     QaseCoreReporter,
 ]

--- a/qase-python-commons/src/qase/commons/reporters/testops_multi.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops_multi.py
@@ -1,0 +1,335 @@
+import threading
+import urllib.parse
+import copy
+
+from datetime import datetime
+from typing import List, Union, Dict, Optional
+from .. import Logger, ReporterException
+from ..client.base_api_client import BaseApiClient
+from ..models import Result
+from ..models.config.qaseconfig import QaseConfig
+
+DEFAULT_BATCH_SIZE = 200
+DEFAULT_THREAD_COUNT = 4
+
+
+class QaseTestOpsMulti:
+
+    def __init__(self, config: QaseConfig, logger: Logger, client: BaseApiClient) -> None:
+        self.config = config
+        self.logger = logger
+        self.__baseUrl = self.__get_host(config.testops.api.host)
+        self.client = client
+
+        self.multi_config = config.testops_multi
+        self.batch_size = min(2000, max(1, int(self.config.testops.batch.size or DEFAULT_BATCH_SIZE)))
+        self.send_semaphore = threading.Semaphore(DEFAULT_THREAD_COUNT)
+        self.lock = threading.Lock()
+        self.count_running_threads = 0
+
+        # Create dictionary mapping project codes to their configurations
+        self.project_configs: Dict[str, Dict] = {}
+        for project in self.multi_config.projects:
+            self.project_configs[project.code] = {
+                'config': project,
+                'run_id': None,
+                'plan_id': int(project.plan.id) if project.plan and project.plan.id else None,
+                'environment': None,
+                'run_title': None,
+                'run_description': None,
+                'complete_after_run': project.run.complete if project.run else True,
+            }
+
+        # Initialize structures for grouping results by projects
+        self.project_results: Dict[str, List[Result]] = {project.code: [] for project in self.multi_config.projects}
+        self.project_runs: Dict[str, int] = {}  # Store run_id as int
+        self.processed: Dict[str, List[Result]] = {project.code: [] for project in self.multi_config.projects}
+
+        # Initialize environment for each project
+        for project_code, project_data in self.project_configs.items():
+            project_config = project_data['config']
+            environment = project_config.environment or self.config.environment
+            
+            if environment:
+                if isinstance(environment, int) or (isinstance(environment, str) and environment.isnumeric()):
+                    project_data['environment'] = environment
+                elif isinstance(environment, str):
+                    project_data['environment'] = self.client.get_environment(environment, project_code)
+
+            # Set run title and description for each project
+            run_title = project_config.run.title if project_config.run else None
+            if run_title and run_title != '':
+                project_data['run_title'] = run_title
+            else:
+                project_data['run_title'] = f"Automated Run {project_code} {str(datetime.now())}"
+
+            run_description = project_config.run.description if project_config.run else None
+            if run_description and run_description != '':
+                project_data['run_description'] = run_description
+            else:
+                project_data['run_description'] = f"Automated Run {project_code} {str(datetime.now())}"
+
+            # Set run_id if specified in config
+            if project_config.run and project_config.run.id:
+                project_data['run_id'] = int(project_config.run.id)
+
+        # Verify that all projects exist in TestOps
+        for project_code in self.project_configs.keys():
+            self.client.get_project(project_code)
+
+    def _create_project_result(self, result: Result, project_code: str, testops_ids: Optional[List[int]]) -> Result:
+        """
+        Create a copy of result with specific testops_ids for a project.
+        
+        :param result: Original result
+        :param project_code: Project code
+        :param testops_ids: List of test case IDs for this project (can be empty or None)
+        :return: Copy of result with testops_ids set
+        """
+        # Create a deep copy of the result
+        project_result = copy.deepcopy(result)
+        
+        # Set testops_ids for this project (can be None or empty list for tests without IDs)
+        project_result.testops_ids = testops_ids if testops_ids else None
+        
+        # Clear project mapping as we're sending to specific project
+        project_result.testops_project_mapping = None
+        
+        return project_result
+
+    def _send_results_threaded(self, project_code: str, run_id: Union[str, int], results: List[Result]):
+        try:
+            # Convert run_id to str for send_results (it will convert to int internally for API)
+            run_id_str = str(run_id) if isinstance(run_id, int) else run_id
+            self.client.send_results(project_code, run_id_str, results)
+            with self.lock:
+                self.processed[project_code].extend(results)
+        except Exception as e:
+            with self.lock:
+                self.logger.log(f"Error at sending results for project {project_code}, run {run_id}: {e}", "error")
+            raise
+        finally:
+            self.count_running_threads -= 1
+            self.send_semaphore.release()
+
+    def _send_results_for_project(self, project_code: str) -> None:
+        """Send results for a specific project."""
+        results = self.project_results[project_code]
+        if not results:
+            return
+
+        run_id = self.project_runs.get(project_code)
+        if not run_id:
+            self.logger.log(f"No run_id for project {project_code}, skipping send", "warning")
+            return
+
+        # Filter results by status if status_filter is configured
+        results_to_send = results.copy()
+        
+        if self.config.testops.status_filter and len(self.config.testops.status_filter) > 0:
+            filtered_results = []
+            for result in results_to_send:
+                result_status = result.get_status()
+                if result_status and result_status not in self.config.testops.status_filter:
+                    filtered_results.append(result)
+                else:
+                    self.logger.log_debug(f"Filtering out result '{result.title}' with status '{result_status}' for project {project_code}")
+            
+            results_to_send = filtered_results
+            self.logger.log_debug(f"Filtered {len(results) - len(results_to_send)} results by status filter for project {project_code}")
+        
+        if results_to_send:
+            # Acquire semaphore before starting the send operation
+            self.send_semaphore.acquire()
+            self.count_running_threads += 1
+
+            # Start a new thread for sending results
+            # run_id is stored as int, convert to str for thread (will be converted back to int in send_results)
+            run_id_for_thread = str(run_id) if isinstance(run_id, int) else run_id
+            send_thread = threading.Thread(target=self._send_results_threaded, args=(project_code, run_id_for_thread, results_to_send))
+            send_thread.start()
+        else:
+            self.logger.log(f"No results to send for project {project_code} after filtering", "info")
+        
+        # Clear results regardless of filtering
+        self.project_results[project_code] = []
+
+    def _send_results(self) -> None:
+        """Send results for all projects."""
+        for project_code in self.project_configs.keys():
+            self._send_results_for_project(project_code)
+
+    def set_run_id(self, project_code: str, run_id: Union[str, int]) -> None:
+        """Set run_id for a specific project."""
+        if project_code in self.project_runs:
+            self.project_runs[project_code] = int(run_id) if isinstance(run_id, str) else run_id
+        else:
+            self.logger.log(f"Unknown project code: {project_code}", "warning")
+
+    def start_run(self) -> Dict[str, int]:
+        """
+        Create or verify test runs for all projects.
+        
+        :return: Dictionary mapping project codes to run IDs (as integers)
+        """
+        for project_code, project_data in self.project_configs.items():
+            run_id = project_data.get('run_id')
+            plan_id = project_data.get('plan_id')
+            run_title = project_data.get('run_title')
+            run_description = project_data.get('run_description')
+            environment_id = project_data.get('environment')
+
+            # If run_id is already set, verify it exists
+            if run_id:
+                run_id_int = int(run_id) if isinstance(run_id, str) else run_id
+                if not self.client.check_test_run(project_code, run_id_int):
+                    raise ReporterException(f"Unable to find given test run {run_id_int} for project {project_code}.")
+                self.project_runs[project_code] = run_id_int
+                continue
+
+            # Create new test run
+            if plan_id:
+                created_run_id = self.client.create_test_run(
+                    project_code=project_code,
+                    title=run_title,
+                    description=run_description,
+                    plan_id=plan_id,
+                    environment_id=environment_id
+                )
+            else:
+                created_run_id = self.client.create_test_run(
+                    project_code=project_code,
+                    title=run_title,
+                    description=run_description,
+                    environment_id=environment_id
+                )
+            
+            # Store run_id as int (API expects int)
+            self.project_runs[project_code] = int(created_run_id) if isinstance(created_run_id, str) else created_run_id
+            self.logger.log_debug(f"Created test run {self.project_runs[project_code]} for project {project_code}")
+
+        return self.project_runs.copy()
+
+    def complete_run(self) -> None:
+        """Complete all test runs for all projects."""
+        # Send remaining results for all projects
+        if any(len(results) > 0 for results in self.project_results.values()):
+            self._send_results()
+
+        # Wait for all send operations to complete
+        while self.count_running_threads > 0:
+            pass
+
+        # Complete all test runs
+        for project_code, project_data in self.project_configs.items():
+            if project_data.get('complete_after_run'):
+                run_id = self.project_runs.get(project_code)
+                if run_id:
+                    self.logger.log_debug(f"Completing run {run_id} for project {project_code}")
+                    self.client.complete_run(project_code, int(run_id))
+                    self.logger.log_debug(f"Run {run_id} completed for project {project_code}")
+
+                    # Enable public report if configured
+                    if self.config.testops.show_public_report_link:
+                        try:
+                            self.logger.log_debug(f"Enabling public report for project {project_code}")
+                            public_url = self.client.enable_public_report(project_code, int(run_id))
+                            if public_url:
+                                self.logger.log(f"Public report link for {project_code}: {public_url}", "info")
+                            else:
+                                self.logger.log(f"Failed to generate public report link for {project_code}", "warning")
+                        except Exception as e:
+                            self.logger.log(f"Failed to generate public report link for {project_code}: {e}", "warning")
+
+    def complete_worker(self) -> None:
+        """Complete worker - send remaining results."""
+        if any(len(results) > 0 for results in self.project_results.values()):
+            self._send_results()
+        while self.count_running_threads > 0:
+            pass
+        self.logger.log_debug("Worker completed")
+
+    def add_result(self, result: Result) -> None:
+        """
+        Add result to appropriate projects based on project mapping.
+        
+        :param result: Test result to add
+        """
+        # Get project mapping from result
+        project_mapping = result.get_testops_project_mapping()
+
+        if not project_mapping:
+            # If no mapping, use default project or first project from config
+            default_project = self.multi_config.default_project
+            if not default_project and self.multi_config.projects:
+                # Use first project from config if default_project is not specified
+                default_project = self.multi_config.projects[0].code
+                self.logger.log_debug(f"No default_project specified, using first project: {default_project}")
+            
+            if default_project:
+                testops_ids = result.get_testops_ids() or []
+                # Send result even if no testops_ids (test without ID)
+                project_mapping = {default_project: testops_ids}
+            else:
+                self.logger.log(f"No project mapping and no projects configured for result {result.title}", "warning")
+                return
+
+        # Process result for each project in mapping
+        for project_code, testops_ids in project_mapping.items():
+            if project_code not in self.project_configs:
+                self.logger.log(f"Unknown project {project_code} for result {result.title}, skipping", "warning")
+                continue
+
+            # Allow results without testops_ids (tests without IDs)
+            # if not testops_ids:
+            #     self.logger.log_debug(f"No testops_ids for project {project_code} in result {result.title}, skipping")
+            #     continue
+
+            # Create project-specific result
+            project_result = self._create_project_result(result, project_code, testops_ids)
+
+            # Show link for failed tests (only if testops_ids are present)
+            if project_result.get_status() == 'failed' and testops_ids:
+                self.__show_link(project_code, testops_ids, project_result.title)
+
+            # Add to project queue
+            self.project_results[project_code].append(project_result)
+
+            # Check batch size and send if needed
+            if len(self.project_results[project_code]) >= self.batch_size:
+                self._send_results_for_project(project_code)
+
+    def get_results(self) -> Dict[str, List[Result]]:
+        """Get all results (pending + processed) grouped by project."""
+        all_results = {}
+        for project_code in self.project_configs.keys():
+            all_results[project_code] = self.project_results[project_code] + self.processed[project_code]
+        return all_results
+
+    def set_results(self, results: Dict[str, List[Result]]) -> None:
+        """Set results for projects."""
+        for project_code, project_results in results.items():
+            if project_code in self.project_results:
+                self.project_results[project_code] = project_results
+
+    def __show_link(self, project_code: str, ids: Union[None, List[int]], title: str):
+        """Show link to failed test."""
+        link = self.__prepare_link(project_code, ids, title)
+        self.logger.log(f"See why this test failed: {link}", "info")
+
+    def __prepare_link(self, project_code: str, ids: Union[None, List[int]], title: str):
+        """Prepare link to test in Qase."""
+        run_id = self.project_runs.get(project_code, '')
+        # Ensure run_id is converted to string for URL
+        run_id_str = str(run_id) if run_id else ''
+        link = f"{self.__baseUrl}/run/{project_code}/dashboard/{run_id_str}?source=logs&status=%5B2%5D&search="
+        if ids is not None and len(ids) > 0:
+            return f"{link}{project_code}-{ids[0]}"
+        return f"{link}{urllib.parse.quote_plus(title)}"
+
+    @staticmethod
+    def __get_host(host: str):
+        """Get host URL for Qase."""
+        if host == 'qase.io':
+            return 'https://app.qase.io'
+        return f'https://{host.replace("api", "app")}'

--- a/qase-python-commons/tests/tests_qase_commons/models/test_result.py
+++ b/qase-python-commons/tests/tests_qase_commons/models/test_result.py
@@ -1,0 +1,124 @@
+"""
+Tests for Result model, including multi-project support.
+"""
+import pytest
+from qase.commons.models.result import Result
+
+
+class TestResultProjectMapping:
+    """Test cases for Result model project mapping functionality."""
+
+    def test_result_initialization_without_mapping(self):
+        """Test that Result initializes without project mapping."""
+        result = Result("Test Title", "test_signature")
+        assert result.testops_project_mapping is None
+        assert result.testops_ids is None
+
+    def test_set_testops_project_mapping_single_project(self):
+        """Test setting project mapping for a single project."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        
+        assert result.testops_project_mapping is not None
+        assert result.testops_project_mapping["PROJ1"] == [123, 124]
+
+    def test_set_testops_project_mapping_multiple_projects(self):
+        """Test setting project mapping for multiple projects."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        result.set_testops_project_mapping("PROJ2", [456, 457])
+        
+        assert result.testops_project_mapping is not None
+        assert result.testops_project_mapping["PROJ1"] == [123, 124]
+        assert result.testops_project_mapping["PROJ2"] == [456, 457]
+
+    def test_set_testops_project_mapping_overwrite(self):
+        """Test that setting mapping for same project overwrites previous values."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        result.set_testops_project_mapping("PROJ1", [999])
+        
+        assert result.testops_project_mapping["PROJ1"] == [999]
+
+    def test_get_testops_project_mapping_empty(self):
+        """Test getting project mapping when it's empty."""
+        result = Result("Test Title", "test_signature")
+        assert result.get_testops_project_mapping() is None
+
+    def test_get_testops_project_mapping_with_data(self):
+        """Test getting project mapping with data."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        result.set_testops_project_mapping("PROJ2", [456])
+        
+        mapping = result.get_testops_project_mapping()
+        assert mapping is not None
+        assert mapping == {"PROJ1": [123, 124], "PROJ2": [456]}
+
+    def test_get_testops_ids_for_project_existing(self):
+        """Test getting IDs for an existing project."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        
+        ids = result.get_testops_ids_for_project("PROJ1")
+        assert ids == [123, 124]
+
+    def test_get_testops_ids_for_project_nonexistent(self):
+        """Test getting IDs for a non-existent project."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        
+        ids = result.get_testops_ids_for_project("PROJ2")
+        assert ids is None
+
+    def test_get_testops_ids_for_project_no_mapping(self):
+        """Test getting IDs when mapping is None."""
+        result = Result("Test Title", "test_signature")
+        
+        ids = result.get_testops_ids_for_project("PROJ1")
+        assert ids is None
+
+    def test_get_projects_empty(self):
+        """Test getting projects list when mapping is empty."""
+        result = Result("Test Title", "test_signature")
+        
+        projects = result.get_projects()
+        assert projects == []
+
+    def test_get_projects_single(self):
+        """Test getting projects list with single project."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        
+        projects = result.get_projects()
+        assert projects == ["PROJ1"]
+
+    def test_get_projects_multiple(self):
+        """Test getting projects list with multiple projects."""
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        result.set_testops_project_mapping("PROJ2", [456])
+        result.set_testops_project_mapping("PROJ3", [789, 790])
+        
+        projects = result.get_projects()
+        assert len(projects) == 3
+        assert "PROJ1" in projects
+        assert "PROJ2" in projects
+        assert "PROJ3" in projects
+
+    def test_backward_compatibility_testops_ids(self):
+        """Test that backward compatibility with testops_ids is maintained."""
+        result = Result("Test Title", "test_signature")
+        result.testops_ids = [123, 124]
+        
+        assert result.get_testops_ids() == [123, 124]
+        assert result.testops_project_mapping is None
+
+    def test_project_mapping_and_testops_ids_coexist(self):
+        """Test that project mapping and testops_ids can coexist."""
+        result = Result("Test Title", "test_signature")
+        result.testops_ids = [999]  # Old single-project IDs
+        result.set_testops_project_mapping("PROJ1", [123, 124])  # New multi-project
+        
+        assert result.get_testops_ids() == [999]
+        assert result.get_testops_project_mapping() == {"PROJ1": [123, 124]}

--- a/qase-python-commons/tests/tests_qase_commons/test_testops_multi.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_testops_multi.py
@@ -1,0 +1,343 @@
+"""
+Tests for QaseTestOpsMulti reporter.
+"""
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from qase.commons.reporters.testops_multi import QaseTestOpsMulti
+from qase.commons.models.result import Result
+from qase.commons.models.config.testops import ProjectConfig, TestopsMultiConfig
+from qase.commons.models.config.qaseconfig import QaseConfig, Mode
+
+
+class TestQaseTestOpsMulti:
+    """Test cases for QaseTestOpsMulti reporter."""
+
+    def _create_mock_config(self):
+        """Helper to create mock configuration."""
+        mock_config = Mock(spec=QaseConfig)
+        mock_config.mode = Mode.testops_multi
+        mock_config.testops = Mock()
+        mock_config.testops.api = Mock()
+        mock_config.testops.api.host = "qase.io"
+        mock_config.testops.api.token = "test_token"
+        mock_config.testops.batch = Mock()
+        mock_config.testops.batch.size = 200
+        mock_config.testops.status_filter = []
+        mock_config.testops.show_public_report_link = False
+        mock_config.environment = None
+        
+        # Create multi-config
+        mock_config.testops_multi = TestopsMultiConfig()
+        mock_config.testops_multi.set_default_project("PROJ1")
+        
+        # Add projects
+        project1 = ProjectConfig()
+        project1.set_code("PROJ1")
+        project1.run.set_title("Project 1 Run")
+        project1.run.set_description("Description 1")
+        
+        project2 = ProjectConfig()
+        project2.set_code("PROJ2")
+        project2.run.set_title("Project 2 Run")
+        project2.run.set_description("Description 2")
+        
+        mock_config.testops_multi.set_projects([project1, project2])
+        
+        return mock_config
+
+    def _create_mock_client(self):
+        """Helper to create mock API client."""
+        mock_client = Mock()
+        mock_client.get_project.return_value = None
+        mock_client.get_environment.return_value = None
+        mock_client.check_test_run.return_value = True
+        mock_client.create_test_run.return_value = 123
+        mock_client.send_results = Mock()
+        mock_client.complete_run = Mock()
+        return mock_client
+
+    def test_init_with_multiple_projects(self):
+        """Test initialization with multiple projects."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        
+        assert len(reporter.project_configs) == 2
+        assert "PROJ1" in reporter.project_configs
+        assert "PROJ2" in reporter.project_configs
+        assert len(reporter.project_results) == 2
+        assert "PROJ1" in reporter.project_results
+        assert "PROJ2" in reporter.project_results
+
+    def test_start_run_creates_runs_for_all_projects(self):
+        """Test that start_run creates runs for all projects."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        mock_client.create_test_run.side_effect = [123, 456]
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        run_ids = reporter.start_run()
+        
+        assert len(run_ids) == 2
+        assert run_ids["PROJ1"] == 123
+        assert run_ids["PROJ2"] == 456
+        assert mock_client.create_test_run.call_count == 2
+
+    def test_start_run_with_existing_run_id(self):
+        """Test start_run with existing run IDs in config."""
+        mock_config = self._create_mock_config()
+        mock_config.testops_multi.projects[0].run.set_id(999)
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        run_ids = reporter.start_run()
+        
+        assert run_ids["PROJ1"] == 999
+        mock_client.check_test_run.assert_called_with("PROJ1", 999)
+        mock_client.create_test_run.assert_called_once()  # Only for PROJ2
+
+    def test_start_run_with_plan_id(self):
+        """Test start_run with test plan ID."""
+        mock_config = self._create_mock_config()
+        mock_config.testops_multi.projects[0].plan.set_id(789)
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        mock_client.create_test_run.return_value = 123
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        run_ids = reporter.start_run()
+        
+        # Verify create_test_run was called with plan_id for PROJ1
+        calls = mock_client.create_test_run.call_args_list
+        assert any("plan_id" in str(call) or call[1].get("plan_id") == 789 for call in calls)
+
+    def test_set_run_id(self):
+        """Test setting run ID for a project."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        # Initialize project_runs with project codes (normally done in start_run)
+        # But set_run_id can be called before start_run, so we need to handle it
+        reporter.project_runs["PROJ1"] = None
+        reporter.set_run_id("PROJ1", "123")
+        
+        assert reporter.project_runs["PROJ1"] == 123
+        # Verify logger was not called (no warning)
+        mock_logger.log.assert_not_called()
+
+    def test_set_run_id_string_conversion(self):
+        """Test that set_run_id converts string to int."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        # Initialize project_runs with project codes (normally done in start_run)
+        reporter.project_runs["PROJ1"] = None
+        reporter.set_run_id("PROJ1", "456")
+        
+        assert isinstance(reporter.project_runs["PROJ1"], int)
+        assert reporter.project_runs["PROJ1"] == 456
+        # Verify logger was not called (no warning)
+        mock_logger.log.assert_not_called()
+
+    def test_set_run_id_unknown_project(self):
+        """Test that set_run_id logs warning for unknown project."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.set_run_id("UNKNOWN_PROJ", "123")
+        
+        # Verify warning was logged
+        mock_logger.log.assert_called_once()
+        call_args = mock_logger.log.call_args
+        assert "Unknown project code" in call_args[0][0]
+        assert "warning" in call_args[0] or call_args[1].get("level") == "warning"
+
+    def test_add_result_with_project_mapping(self):
+        """Test adding result with project mapping."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123, 124])
+        result.set_testops_project_mapping("PROJ2", [456])
+        
+        reporter.add_result(result)
+        
+        # Results should be added to both projects
+        assert len(reporter.project_results["PROJ1"]) == 1
+        assert len(reporter.project_results["PROJ2"]) == 1
+
+    def test_add_result_without_mapping_uses_default(self):
+        """Test adding result without mapping uses default project."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        result.testops_ids = [999]  # Old single-project IDs
+        
+        reporter.add_result(result)
+        
+        # Should go to default project (PROJ1)
+        assert len(reporter.project_results["PROJ1"]) == 1
+        assert len(reporter.project_results["PROJ2"]) == 0
+
+    def test_add_result_without_mapping_no_default_uses_first(self):
+        """Test adding result without mapping and no default uses first project."""
+        mock_config = self._create_mock_config()
+        mock_config.testops_multi.default_project = None
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        
+        reporter.add_result(result)
+        
+        # Should go to first project (PROJ1)
+        assert len(reporter.project_results["PROJ1"]) == 1
+
+    def test_add_result_creates_project_specific_copies(self):
+        """Test that add_result creates separate copies for each project."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123])
+        result.set_testops_project_mapping("PROJ2", [456])
+        
+        reporter.add_result(result)
+        
+        # Verify copies have correct testops_ids
+        proj1_result = reporter.project_results["PROJ1"][0]
+        proj2_result = reporter.project_results["PROJ2"][0]
+        
+        assert proj1_result.testops_ids == [123]
+        assert proj2_result.testops_ids == [456]
+        assert proj1_result.testops_project_mapping is None
+        assert proj2_result.testops_project_mapping is None
+
+    def test_create_project_result(self):
+        """Test _create_project_result method."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        
+        original_result = Result("Test Title", "test_signature")
+        original_result.set_testops_project_mapping("PROJ1", [123])
+        original_result.set_testops_project_mapping("PROJ2", [456])
+        
+        project_result = reporter._create_project_result(original_result, "PROJ1", [123])
+        
+        assert project_result.testops_ids == [123]
+        assert project_result.testops_project_mapping is None
+        assert project_result.title == "Test Title"
+        # Verify they are different objects (deepcopy creates new object)
+        assert id(project_result) != id(original_result)
+        # Verify modifying one doesn't affect the other
+        project_result.title = "Modified Title"
+        assert original_result.title == "Test Title"
+
+    def test_create_project_result_with_none_ids(self):
+        """Test _create_project_result with None IDs."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        
+        original_result = Result("Test Title", "test_signature")
+        project_result = reporter._create_project_result(original_result, "PROJ1", None)
+        
+        assert project_result.testops_ids is None
+
+    def test_send_results_for_project(self):
+        """Test sending results for a specific project."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123])
+        reporter.add_result(result)
+        
+        # Manually trigger send (normally done by batch size or complete_run)
+        reporter._send_results_for_project("PROJ1")
+        
+        # Wait a bit for thread to complete
+        import time
+        time.sleep(0.1)
+        
+        # Verify results were sent
+        assert len(reporter.project_results["PROJ1"]) == 0  # Queue cleared
+        mock_client.send_results.assert_called()
+
+    def test_complete_run_sends_remaining_results(self):
+        """Test that complete_run sends remaining results."""
+        mock_config = self._create_mock_config()
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        result = Result("Test Title", "test_signature")
+        result.set_testops_project_mapping("PROJ1", [123])
+        reporter.add_result(result)
+        
+        reporter.complete_run()
+        
+        # Wait for threads
+        import time
+        time.sleep(0.2)
+        
+        # Verify complete_run was called
+        mock_client.complete_run.assert_called()
+
+    def test_complete_run_with_public_report(self):
+        """Test complete_run with public report enabled."""
+        mock_config = self._create_mock_config()
+        mock_config.testops.show_public_report_link = True
+        mock_logger = Mock()
+        mock_client = self._create_mock_client()
+        mock_client.enable_public_report.return_value = "https://app.qase.io/public/report/abc123"
+        
+        reporter = QaseTestOpsMulti(mock_config, mock_logger, mock_client)
+        reporter.start_run()
+        
+        reporter.complete_run()
+        
+        # Wait for threads
+        import time
+        time.sleep(0.2)
+        
+        # Verify public report was enabled
+        mock_client.enable_public_report.assert_called()

--- a/qase-python-commons/tests/tests_qase_commons/test_testops_multi_config.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_testops_multi_config.py
@@ -1,0 +1,139 @@
+"""
+Tests for TestopsMultiConfig and ProjectConfig models.
+"""
+import pytest
+from qase.commons.models.config.testops import ProjectConfig, TestopsMultiConfig, RunConfig, PlanConfig
+
+
+class TestProjectConfig:
+    """Test cases for ProjectConfig model."""
+
+    def test_project_config_initialization(self):
+        """Test ProjectConfig initialization with default values."""
+        config = ProjectConfig()
+        
+        assert config.code is None
+        assert config.run is not None
+        assert isinstance(config.run, RunConfig)
+        assert config.plan is not None
+        assert isinstance(config.plan, PlanConfig)
+        assert config.environment is None
+
+    def test_project_config_set_code(self):
+        """Test setting project code."""
+        config = ProjectConfig()
+        config.set_code("PROJ1")
+        
+        assert config.code == "PROJ1"
+
+    def test_project_config_set_environment(self):
+        """Test setting environment."""
+        config = ProjectConfig()
+        config.set_environment("staging")
+        
+        assert config.environment == "staging"
+
+    def test_project_config_set_run_from_dict(self):
+        """Test setting run configuration from dictionary."""
+        config = ProjectConfig()
+        run_dict = {
+            "title": "Test Run",
+            "description": "Description",
+            "complete": True,
+            "id": 123,
+            "tags": ["tag1", "tag2"]
+        }
+        config.set_run(run_dict)
+        
+        assert config.run.title == "Test Run"
+        assert config.run.description == "Description"
+        assert config.run.complete is True
+        assert config.run.id == 123
+        assert config.run.tags == ["tag1", "tag2"]
+
+    def test_project_config_set_run_partial(self):
+        """Test setting run configuration with partial dictionary."""
+        config = ProjectConfig()
+        run_dict = {
+            "title": "Test Run",
+            "complete": False
+        }
+        config.set_run(run_dict)
+        
+        assert config.run.title == "Test Run"
+        assert config.run.complete is False
+        assert config.run.description is None
+
+    def test_project_config_set_plan_from_dict(self):
+        """Test setting plan configuration from dictionary."""
+        config = ProjectConfig()
+        plan_dict = {"id": 456}
+        config.set_plan(plan_dict)
+        
+        assert config.plan.id == 456
+
+    def test_project_config_set_plan_empty(self):
+        """Test setting plan configuration with empty dictionary."""
+        config = ProjectConfig()
+        config.set_plan({})
+        
+        assert config.plan.id is None
+
+
+class TestTestopsMultiConfig:
+    """Test cases for TestopsMultiConfig model."""
+
+    def test_testops_multi_config_initialization(self):
+        """Test TestopsMultiConfig initialization with default values."""
+        config = TestopsMultiConfig()
+        
+        assert config.default_project is None
+        assert config.projects is not None
+        assert isinstance(config.projects, list)
+        assert len(config.projects) == 0
+
+    def test_testops_multi_config_set_default_project(self):
+        """Test setting default project."""
+        config = TestopsMultiConfig()
+        config.set_default_project("PROJ1")
+        
+        assert config.default_project == "PROJ1"
+
+    def test_testops_multi_config_set_projects(self):
+        """Test setting projects list."""
+        config = TestopsMultiConfig()
+        
+        project1 = ProjectConfig()
+        project1.set_code("PROJ1")
+        
+        project2 = ProjectConfig()
+        project2.set_code("PROJ2")
+        
+        config.set_projects([project1, project2])
+        
+        assert len(config.projects) == 2
+        assert config.projects[0].code == "PROJ1"
+        assert config.projects[1].code == "PROJ2"
+
+    def test_testops_multi_config_add_project(self):
+        """Test adding project to the list."""
+        config = TestopsMultiConfig()
+        
+        project1 = ProjectConfig()
+        project1.set_code("PROJ1")
+        config.add_project(project1)
+        
+        project2 = ProjectConfig()
+        project2.set_code("PROJ2")
+        config.add_project(project2)
+        
+        assert len(config.projects) == 2
+        assert config.projects[0].code == "PROJ1"
+        assert config.projects[1].code == "PROJ2"
+
+    def test_testops_multi_config_empty_projects(self):
+        """Test that projects list can be empty."""
+        config = TestopsMultiConfig()
+        config.set_projects([])
+        
+        assert len(config.projects) == 0


### PR DESCRIPTION
- Updated version to 5.0.0 in pyproject.toml.
- Added support for multi-project reporting, allowing test results to be sent to multiple Qase projects simultaneously.
- Enhanced configuration validation for multi-project setups.
- Introduced new models and methods for managing project-specific test results and configurations.

This release significantly improves the functionality of the Qase Python Commons library, enabling users to manage and report results across multiple projects effectively.