### PR TITLE
chore: release version 5.0.1 with bug fix

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@5.0.1
+
+## What's new
+
+- Fixed an issue where the test run link was not being generated correctly when filtering by status.
+
 # qase-python-commons@5.0.0
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "5.0.0"
+version = "5.0.1"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -177,7 +177,7 @@ class QaseTestOps:
         self.logger.log(f"See why this test failed: {link}", "info")
 
     def __prepare_link(self, ids: Union[None, List[int]], title: str):
-        link = f"{self.__baseUrl}/run/{self.project_code}/dashboard/{self.run_id}?source=logs&status=%5B2%5D&search="
+        link = f"{self.__baseUrl}/run/{self.project_code}/dashboard/{self.run_id}?source=logs&search="
         if ids is not None and len(ids) > 0:
             return f"{link}{self.project_code}-{ids[0]}"
         return f"{link}{urllib.parse.quote_plus(title)}"

--- a/qase-python-commons/src/qase/commons/reporters/testops_multi.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops_multi.py
@@ -322,7 +322,7 @@ class QaseTestOpsMulti:
         run_id = self.project_runs.get(project_code, '')
         # Ensure run_id is converted to string for URL
         run_id_str = str(run_id) if run_id else ''
-        link = f"{self.__baseUrl}/run/{project_code}/dashboard/{run_id_str}?source=logs&status=%5B2%5D&search="
+        link = f"{self.__baseUrl}/run/{project_code}/dashboard/{run_id_str}?source=logs&search="
         if ids is not None and len(ids) > 0:
             return f"{link}{project_code}-{ids[0]}"
         return f"{link}{urllib.parse.quote_plus(title)}"


### PR DESCRIPTION
- Updated version to 5.0.1 in pyproject.toml.
- Fixed an issue where the test run link was not being generated correctly when filtering by status.

This release addresses a critical bug to improve the functionality of the Qase Python Commons library.