### PR TITLE
feat(behave): add BehaveX parallel execution support

### DIFF
--- a/qase-behave/README.md
+++ b/qase-behave/README.md
@@ -14,6 +14,7 @@ Qase Behave Reporter enables seamless integration between your Behave BDD tests 
 - Automatic step reporting from Gherkin scenarios
 - Multi-project reporting support
 - Flexible configuration (file, environment variables)
+- **[BehaveX](https://github.com/hrcorval/behavex) parallel execution support**
 
 ## Installation
 
@@ -204,10 +205,29 @@ export QASE_TESTOPS_RUN_TITLE="Regression Run"
 behave --format=qase.behave.formatter:QaseFormatter
 ```
 
+### Parallel Execution with BehaveX
+
+Run tests in parallel using [BehaveX](https://github.com/hrcorval/behavex) (v4.0.0+):
+
+```sh
+pip install behavex
+
+behavex --formatter=qase.behave.formatter:QaseFormatter --parallel-processes=4 features/
+
+# Parallel by feature
+behavex --formatter=qase.behave.formatter:QaseFormatter --parallel-processes=4 --parallel-scheme=feature features/
+```
+
+Configuration is done via environment variables or `qase.config.json` (the same as for standard behave).
+
+> **Note:** `qase.attach()` and `qase.comment()` are not supported in BehaveX mode. All other features (test case linking, metadata, steps, statuses) work normally.
+
 ## Requirements
 
 - Python >= 3.9
 - behave >= 1.2.6
+- filelock >= 3.12.2
+- BehaveX >= 4.0.0 (optional, for parallel execution)
 
 ## Documentation
 

--- a/qase-behave/changelog.md
+++ b/qase-behave/changelog.md
@@ -1,3 +1,31 @@
+# qase-behave 3.2.0
+
+## What's new
+
+- Added support for [BehaveX](https://github.com/hrcorval/behavex) parallel test execution via `--formatter` flag. BehaveX calls `launch_json_formatter()` with consolidated JSON after all workers complete — scenarios, steps, tags, statuses, and timing are fully reported.
+- Added `launch_json_formatter()` method implementing the BehaveX custom formatter interface
+- Added `parse_scenario_from_json()` and `parse_step_from_json()` utility functions for mapping BehaveX JSON to Qase models
+- Added `filelock` dependency for cross-process run coordination
+
+### BehaveX Usage
+
+```sh
+behavex --formatter=qase.behave.formatter:QaseFormatter --parallel-processes=4 features/
+```
+
+Configuration via environment variables or `qase.config.json`:
+
+```sh
+export QASE_MODE=testops
+export QASE_TESTOPS_PROJECT=PROJ
+export QASE_TESTOPS_API_TOKEN=your_token
+```
+
+### Known Limitations
+
+- `qase.attach()` and `qase.comment()` are not supported in BehaveX mode — tests have already completed when the formatter processes results.
+- Configuration is only available via environment variables or `qase.config.json` (behave `--define` options are not passed to the BehaveX formatter).
+
 # qase-behave 3.1.0
 
 ## What's new

--- a/qase-behave/pyproject.toml
+++ b/qase-behave/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-behave"
-version = "3.1.0"
+version = "3.2.0"
 description = "Qase Behave Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "behave", "plugin", "testops", "report", "qase reporting", "test observability"]
@@ -31,6 +31,7 @@ dependencies = [
     "qase-python-commons~=5.1.1",
     "behave>=1.2.6",
     "more_itertools",
+    "filelock>=3.12.2",
 ]
 
 [project.urls]

--- a/qase-behave/src/qase/behave/formatter.py
+++ b/qase-behave/src/qase/behave/formatter.py
@@ -1,33 +1,71 @@
+import os
+
 from behave.formatter.base import Formatter
 from behave.model import Feature, Scenario, Step
 from qase.commons import ConfigManager
 from qase.commons.reporters import QaseCoreReporter
 
-from qase.behave.utils import filter_scenarios, parse_scenario, parse_step
+from qase.behave.utils import (
+    filter_scenarios, parse_scenario, parse_step,
+    parse_scenario_from_json, parse_step_from_json,
+)
 from qase.behave.qase_global import qase
 
 
 class QaseFormatter(Formatter):
     name = 'qase'
     description = 'Qase.io formatter'
-    __already_started = False
-    __case_ids = []
-    __current_scenario = None
 
-    def __init__(self, stream_opener, config):
-        super(QaseFormatter, self).__init__(stream_opener, config)
+    # Lock file paths for BehaveX worker coordination
+    _run_id_file = "qase_behavex_run_id"
+    _lock_file = "qase_behavex.lock"
 
-        cfg = self.__parse_config(config.userdata)
-        self.reporter = QaseCoreReporter(cfg, 'behave', 'qase-behave')
+    def __init__(self, stream_opener=None, config=None):
+        self._behavex_mode = stream_opener is None and config is None
+        self._is_behavex_worker = False
+        self.__already_started = False
+        self.__case_ids = []
+        self.__current_scenario = None
+
+        if not self._behavex_mode:
+            super().__init__(stream_opener, config)
+            userdata = config.userdata
+            self._is_behavex_worker = 'worker_id' in userdata
+
+            cfg = self.__parse_config(userdata)
+            self.reporter = QaseCoreReporter(cfg, 'behave', 'qase-behave')
+
+            if self._is_behavex_worker:
+                self._init_worker_run()
+        else:
+            self.reporter = None
+
+    def _init_worker_run(self):
+        """Initialize run in BehaveX worker mode with lock file coordination."""
+        from filelock import FileLock
+
+        with FileLock(self._lock_file):
+            if os.path.exists(self._run_id_file):
+                with open(self._run_id_file, "r") as f:
+                    run_id = f.read().strip()
+                self.reporter.set_run_id(run_id)
+            else:
+                run_id = self.reporter.start_run()
+                with open(self._run_id_file, "w") as f:
+                    f.write(str(run_id))
+
+        self.__already_started = True
 
     def uri(self, uri):
-        if not self.__already_started:
+        if self.__already_started:
+            return
+
+        if not self._is_behavex_worker:
             self.reporter.start_run()
 
-            execution_plan = self.reporter.get_execution_plan()
-            self.__case_ids = execution_plan if execution_plan else []
-
-            self.__already_started = True
+        execution_plan = self.reporter.get_execution_plan()
+        self.__case_ids = execution_plan if execution_plan else []
+        self.__already_started = True
 
     def feature(self, feature: Feature):
         feature.scenarios = filter_scenarios(
@@ -39,51 +77,97 @@ class QaseFormatter(Formatter):
             self.reporter.add_result(self.__current_scenario)
             self.__current_scenario = None
         self.__current_scenario = parse_scenario(scenario)
-        # Update global qase object with current scenario
         qase._set_current_scenario(self.__current_scenario)
-        # Clear current step when starting new scenario
         qase._set_current_step(None)
-        pass
 
     def result(self, result: Step):
         step = parse_step(result)
-        # Set current step to allow future attachments and apply pending ones
         qase._set_current_step(step)
-        
+
         if step.execution.status != 'passed':
-            # Check if it's an assertion error or other error
             is_assertion_error = False
             if result.error_message:
-                # Check if the error message contains assertion-related keywords
                 assertion_keywords = ['assert', 'AssertionError', 'expect', 'should', 'must']
                 is_assertion_error = any(keyword in result.error_message for keyword in assertion_keywords)
-            
-            # Set appropriate status
+
             if step.execution.status == 'failed':
                 status = 'failed' if is_assertion_error else 'invalid'
                 step.execution.set_status(status)
                 self.__current_scenario.execution.set_status(status)
             else:
                 self.__current_scenario.execution.set_status(step.execution.status)
-            
+
             if result.error_message:
                 self.__current_scenario.execution.stacktrace = result.error_message
         self.__current_scenario.steps.append(step)
-        # Clear current step after adding to scenario
         qase._set_current_step(None)
-        pass
 
     def eof(self):
         if self.__current_scenario and self.__current_scenario.ignore == False:
             self.__current_scenario.execution.complete()
             self.reporter.add_result(self.__current_scenario)
             self.__current_scenario = None
-        pass
 
     def close(self):
+        if self._is_behavex_worker:
+            self.reporter.complete_worker()
+        else:
+            self.reporter.complete_worker()
+            self.reporter.complete_run()
+
+    def launch_json_formatter(self, json_data):
+        """BehaveX post-execution formatter entry point.
+
+        Called by BehaveX's FormatterManager after all parallel workers complete.
+        Receives consolidated JSON with all test results.
+        """
+        if self.reporter is None:
+            cfg = ConfigManager()
+            self.reporter = QaseCoreReporter(cfg, 'behave', 'qase-behave')
+
+        # Check if workers already sent results (lock file exists)
+        if os.path.exists(self._run_id_file):
+            with open(self._run_id_file, "r") as f:
+                run_id = f.read().strip()
+            self.reporter.set_run_id(run_id)
+            self.reporter.complete_run()
+            self._cleanup_lock_files()
+            return
+
+        # Workers didn't run QaseFormatter — process JSON ourselves
+        self.reporter.start_run()
+
+        for feature in json_data.get('features', []):
+            feature_filename = feature.get('filename', '')
+            for scenario_dict in feature.get('scenarios', []):
+                result = parse_scenario_from_json(scenario_dict, feature_filename)
+
+                if result.ignore:
+                    continue
+
+                # Background steps first
+                background = scenario_dict.get('background', {})
+                for step_dict in background.get('steps', []):
+                    step = parse_step_from_json(step_dict)
+                    result.steps.append(step)
+
+                # Regular steps
+                for step_dict in scenario_dict.get('steps', []):
+                    step = parse_step_from_json(step_dict)
+                    result.steps.append(step)
+
+                self.reporter.add_result(result)
+
         self.reporter.complete_worker()
         self.reporter.complete_run()
-        pass
+
+    def _cleanup_lock_files(self):
+        """Remove lock and run_id files."""
+        for path in (self._run_id_file, self._lock_file):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
 
     @staticmethod
     def __parse_config(userdata) -> ConfigManager:

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -143,6 +143,112 @@ def __extract_fields(tag: str) -> dict:
         return {}
 
 
+def parse_scenario_from_json(scenario_dict: dict, feature_filename: str) -> Result:
+    """Parse a BehaveX JSON scenario dict into a Qase Result."""
+    tags = __parse_tags(scenario_dict.get('tags', []))
+
+    name = scenario_dict.get('name', '')
+    result = Result(name, name)
+
+    project_ids = tags.get(TESTOPS_PROJECT_ID, None)
+    if project_ids:
+        for project_code, testops_ids in project_ids.items():
+            result.set_testops_project_mapping(project_code, testops_ids)
+    else:
+        result.testops_ids = tags.get(TESTOPS_ID, None)
+
+    result.fields = tags.get(FIELDS, {})
+    result.ignore = tags.get(IGNORE, False)
+
+    tag_list = tags.get(TAGS, [])
+    if tag_list:
+        result.add_tags(tag_list)
+
+    relation = Relation()
+    if SUITE in tags:
+        for suite in tags[SUITE]:
+            relation.suite.add_data(SuiteData(suite))
+    else:
+        suites = feature_filename.split(os.sep)
+        for suite in suites:
+            relation.suite.add_data(SuiteData(suite))
+    result.relations = relation
+
+    result.params = scenario_dict.get('parameters', {})
+
+    status_map = {
+        'passed': 'passed',
+        'failed': 'failed',
+        'error': 'invalid',
+        'skipped': 'skipped',
+        'undefined': 'skipped',
+        'untested': 'skipped',
+    }
+    result.execution.set_status(
+        status_map.get(scenario_dict.get('status', 'skipped'), 'skipped')
+    )
+
+    duration = scenario_dict.get('duration', 0)
+    result.execution.duration = int(duration * 1000)
+    if 'start' in scenario_dict:
+        result.execution.start_time = scenario_dict['start']
+    if 'stop' in scenario_dict:
+        result.execution.end_time = scenario_dict['stop']
+
+    worker_id = scenario_dict.get('worker_id')
+    if worker_id is not None:
+        result.execution.thread = f"worker-{worker_id}"
+
+    error_msg = scenario_dict.get('error_msg')
+    if error_msg:
+        if isinstance(error_msg, list):
+            result.execution.stacktrace = '\n'.join(error_msg)
+        else:
+            result.execution.stacktrace = str(error_msg)
+
+    result.signature = QaseUtils.get_signature(
+        result.testops_ids,
+        [suite.title for suite in relation.suite.data] + [name],
+        result.params
+    )
+
+    return result
+
+
+def parse_step_from_json(step_dict: dict) -> QaseStep:
+    """Parse a BehaveX JSON step dict into a Qase Step."""
+    keyword = step_dict.get('step_type', 'given')
+    name = step_dict.get('name', '')
+    line = step_dict.get('line', 0)
+
+    model = QaseStep(
+        step_type=StepType.GHERKIN,
+        id=str(uuid.uuid4()),
+        data=StepGherkinData(keyword=keyword, name=name, line=line)
+    )
+
+    status_mapping = {
+        'passed': 'passed',
+        'failed': 'failed',
+        'error': 'failed',
+        'skipped': 'skipped',
+        'undefined': 'skipped',
+        'untested': 'skipped',
+    }
+    model.execution.set_status(
+        status_mapping.get(step_dict.get('status', 'skipped'), 'skipped')
+    )
+
+    duration = step_dict.get('duration', 0)
+    model.execution.duration = int(duration * 1000)
+    if 'start' in step_dict:
+        model.execution.start_time = step_dict['start']
+    if 'stop' in step_dict:
+        model.execution.end_time = step_dict['stop']
+
+    return model
+
+
 def parse_step(step: Step) -> QaseStep:
     model = QaseStep(
         step_type=StepType.GHERKIN,

--- a/qase-behave/src/qase/behave/utils.py
+++ b/qase-behave/src/qase/behave/utils.py
@@ -190,10 +190,11 @@ def parse_scenario_from_json(scenario_dict: dict, feature_filename: str) -> Resu
 
     duration = scenario_dict.get('duration', 0)
     result.execution.duration = int(duration * 1000)
-    if 'start' in scenario_dict:
-        result.execution.start_time = scenario_dict['start']
-    if 'stop' in scenario_dict:
-        result.execution.end_time = scenario_dict['stop']
+    # Always calculate timestamps relative to current time.
+    # BehaveX timestamps are from before run creation and would be rejected by the API.
+    current_time = QaseUtils.get_real_time()
+    result.execution.end_time = current_time
+    result.execution.start_time = current_time - duration
 
     worker_id = scenario_dict.get('worker_id')
     if worker_id is not None:
@@ -241,10 +242,9 @@ def parse_step_from_json(step_dict: dict) -> QaseStep:
 
     duration = step_dict.get('duration', 0)
     model.execution.duration = int(duration * 1000)
-    if 'start' in step_dict:
-        model.execution.start_time = step_dict['start']
-    if 'stop' in step_dict:
-        model.execution.end_time = step_dict['stop']
+    current_time = QaseUtils.get_real_time()
+    model.execution.end_time = current_time
+    model.execution.start_time = current_time - duration
 
     return model
 

--- a/qase-behave/tests/test_formatter.py
+++ b/qase-behave/tests/test_formatter.py
@@ -7,10 +7,13 @@ multi-project tags, step status mapping, and scenario field handling.
 These tests complement test_utils.py which covers happy paths.
 """
 
+import os
+import tempfile
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from qase.commons.models.step import StepType
 from qase.behave.utils import parse_scenario, parse_step, filter_scenarios
+from qase.behave.formatter import QaseFormatter
 
 
 @pytest.fixture
@@ -176,3 +179,141 @@ class TestFilterScenarios:
         assert len(result) == 2
         assert result[0].tags == ["qase.id:10"]
         assert result[1].tags == ["qase.id:30"]
+
+
+class TestBehaveXPostExecution:
+    """Test launch_json_formatter (BehaveX post-execution mode)."""
+
+    def test_init_without_args(self):
+        """QaseFormatter() with no args should not crash."""
+        formatter = QaseFormatter()
+        assert formatter._behavex_mode is True
+        assert formatter.reporter is None
+
+    def test_launch_json_formatter_processes_features(self):
+        """launch_json_formatter should create run, process scenarios, complete run."""
+        formatter = QaseFormatter()
+        mock_reporter = MagicMock()
+        mock_reporter.start_run.return_value = "123"
+
+        json_data = {
+            "features": [{
+                "name": "Login",
+                "filename": "features/login.feature",
+                "scenarios": [{
+                    "name": "Valid login",
+                    "status": "passed",
+                    "duration": 1.0,
+                    "tags": ["qase.id:1"],
+                    "filename": "features/login.feature",
+                    "line": 5,
+                    "steps": [{
+                        "step_type": "given",
+                        "name": "a user",
+                        "status": "passed",
+                        "duration": 0.5,
+                        "line": 6,
+                    }],
+                    "background": {"steps": []},
+                }],
+            }],
+        }
+
+        with patch('qase.behave.formatter.QaseCoreReporter', return_value=mock_reporter), \
+             patch('qase.behave.formatter.ConfigManager'):
+            formatter.launch_json_formatter(json_data)
+
+        mock_reporter.start_run.assert_called_once()
+        mock_reporter.add_result.assert_called_once()
+        mock_reporter.complete_worker.assert_called_once()
+        mock_reporter.complete_run.assert_called_once()
+
+    def test_launch_json_formatter_skips_ignored_scenarios(self):
+        """Scenarios with qase.ignore tag should not be reported."""
+        formatter = QaseFormatter()
+        mock_reporter = MagicMock()
+        mock_reporter.start_run.return_value = "123"
+
+        json_data = {
+            "features": [{
+                "name": "Feature",
+                "filename": "features/f.feature",
+                "scenarios": [{
+                    "name": "Ignored",
+                    "status": "passed",
+                    "duration": 0.1,
+                    "tags": ["qase.ignore"],
+                    "filename": "features/f.feature",
+                    "line": 1,
+                    "steps": [],
+                    "background": {"steps": []},
+                }],
+            }],
+        }
+
+        with patch('qase.behave.formatter.QaseCoreReporter', return_value=mock_reporter), \
+             patch('qase.behave.formatter.ConfigManager'):
+            formatter.launch_json_formatter(json_data)
+
+        mock_reporter.add_result.assert_not_called()
+
+    def test_launch_json_formatter_with_existing_lock_file(self):
+        """If lock file exists (workers already sent results), just complete the run."""
+        formatter = QaseFormatter()
+        mock_reporter = MagicMock()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='_run_id', delete=False) as f:
+            f.write("456")
+            lock_path = f.name
+
+        try:
+            formatter._run_id_file = lock_path
+            formatter._lock_file = lock_path + ".lock"
+
+            with patch('qase.behave.formatter.QaseCoreReporter', return_value=mock_reporter), \
+                 patch('qase.behave.formatter.ConfigManager'):
+                formatter.launch_json_formatter({"features": []})
+
+            mock_reporter.set_run_id.assert_called_once_with("456")
+            mock_reporter.start_run.assert_not_called()
+            mock_reporter.complete_run.assert_called_once()
+        finally:
+            if os.path.exists(lock_path):
+                os.remove(lock_path)
+
+
+class TestBehaveXWorkerMode:
+    """Test QaseFormatter in BehaveX worker mode (lock file coordination)."""
+
+    def test_detects_behavex_worker(self):
+        """Formatter detects BehaveX worker via worker_id in userdata."""
+        mock_config = MagicMock()
+        mock_config.userdata = {"worker_id": "0"}
+        mock_reporter = MagicMock()
+        mock_reporter.start_run.return_value = "789"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_id_path = os.path.join(tmpdir, "qase_run_id")
+            lock_path = os.path.join(tmpdir, "qase.lock")
+
+            with patch('qase.behave.formatter.QaseCoreReporter', return_value=mock_reporter), \
+                 patch.object(QaseFormatter, '_run_id_file', run_id_path), \
+                 patch.object(QaseFormatter, '_lock_file', lock_path), \
+                 patch('qase.behave.formatter.ConfigManager'):
+                formatter = QaseFormatter(MagicMock(), mock_config)
+
+            assert formatter._is_behavex_worker is True
+            mock_reporter.start_run.assert_called_once()
+
+    def test_worker_close_calls_complete_worker_not_complete_run(self):
+        """In BehaveX worker mode, close() should call complete_worker() only."""
+        formatter = QaseFormatter()
+        formatter._behavex_mode = False
+        formatter._is_behavex_worker = True
+        formatter.reporter = MagicMock()
+        formatter._QaseFormatter__current_scenario = None
+
+        formatter.close()
+
+        formatter.reporter.complete_worker.assert_called_once()
+        formatter.reporter.complete_run.assert_not_called()

--- a/qase-behave/tests/test_utils.py
+++ b/qase-behave/tests/test_utils.py
@@ -2,7 +2,8 @@ import pytest
 from unittest.mock import MagicMock
 from qase.commons.models.step import StepType
 from qase.behave.utils import (
-    filter_scenarios, parse_scenario, parse_step, __extract_fields
+    filter_scenarios, parse_scenario, parse_step, __extract_fields,
+    parse_scenario_from_json, parse_step_from_json,
 )
 
 
@@ -114,3 +115,230 @@ def test_parse_scenario_without_tags_has_empty_list(mock_scenario):
     scenario = mock_scenario(tags=["qase.id:100"])
     result = parse_scenario(scenario)
     assert result.tags == []
+
+
+class TestParseScenarioFromJson:
+    """Tests for parse_scenario_from_json(scenario_dict, feature_filename)."""
+
+    def test_basic_scenario(self):
+        scenario_dict = {
+            'name': 'Login with valid credentials',
+            'status': 'passed',
+            'duration': 1.5,
+            'tags': [],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/login.feature')
+        assert result.title == 'Login with valid credentials'
+        assert result.execution.status == 'passed'
+        assert result.execution.duration == 1500
+
+    def test_failed_scenario_with_error(self):
+        scenario_dict = {
+            'name': 'Failing test',
+            'status': 'failed',
+            'duration': 0.3,
+            'tags': [],
+            'error_msg': ['AssertionError: expected True', 'got False'],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.execution.status == 'failed'
+        assert 'AssertionError: expected True' in result.execution.stacktrace
+        assert 'got False' in result.execution.stacktrace
+
+    def test_error_scenario_maps_to_invalid(self):
+        scenario_dict = {
+            'name': 'Error test',
+            'status': 'error',
+            'duration': 0.1,
+            'tags': [],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.execution.status == 'invalid'
+
+    def test_qase_id_tag_parsing(self):
+        scenario_dict = {
+            'name': 'Tagged test',
+            'status': 'passed',
+            'duration': 0.5,
+            'tags': ['qase.id:42'],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.testops_ids == [42]
+
+    def test_multiple_qase_tags(self):
+        scenario_dict = {
+            'name': 'Multi-tag test',
+            'status': 'passed',
+            'duration': 0.5,
+            'tags': [
+                'qase.id:10',
+                'qase.suite:Auth||Login',
+                'qase.fields:{"priority":"high"}',
+                'qase.tags:smoke,regression',
+            ],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.testops_ids == [10]
+        assert len(result.relations.suite.data) == 2
+        assert result.relations.suite.data[0].title == 'Auth'
+        assert result.relations.suite.data[1].title == 'Login'
+        assert result.fields.get('priority') == 'high'
+        assert 'smoke' in result.tags
+        assert 'regression' in result.tags
+
+    def test_multi_project_tags(self):
+        scenario_dict = {
+            'name': 'Multi-project test',
+            'status': 'passed',
+            'duration': 0.5,
+            'tags': ['qase.project_id.PROJ1:1,2'],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        mapping = result.get_testops_project_mapping()
+        assert mapping is not None
+        assert mapping['PROJ1'] == [1, 2]
+
+    def test_ignore_tag(self):
+        scenario_dict = {
+            'name': 'Ignored test',
+            'status': 'passed',
+            'duration': 0.1,
+            'tags': ['qase.ignore'],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.ignore is True
+
+    def test_scenario_outline_parameters(self):
+        scenario_dict = {
+            'name': 'Parameterized test',
+            'status': 'passed',
+            'duration': 0.2,
+            'tags': [],
+            'parameters': {'username': 'admin', 'password': 'secret'},
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.params == {'username': 'admin', 'password': 'secret'}
+
+    def test_suite_from_filename_when_no_suite_tag(self):
+        scenario_dict = {
+            'name': 'Suite from path',
+            'status': 'passed',
+            'duration': 0.1,
+            'tags': [],
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/auth/login.feature')
+        suite_titles = [s.title for s in result.relations.suite.data]
+        assert 'features' in suite_titles
+        assert 'auth' in suite_titles
+        assert 'login.feature' in suite_titles
+
+    def test_start_stop_timestamps(self):
+        scenario_dict = {
+            'name': 'Timed test',
+            'status': 'passed',
+            'duration': 1.0,
+            'tags': [],
+            'start': 1700000000.0,
+            'stop': 1700000001.0,
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.execution.start_time == 1700000000.0
+        assert result.execution.end_time == 1700000001.0
+
+    def test_thread_from_worker_id(self):
+        scenario_dict = {
+            'name': 'Parallel test',
+            'status': 'passed',
+            'duration': 0.5,
+            'tags': [],
+            'worker_id': '2',
+        }
+        result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+        assert result.execution.thread == 'worker-2'
+
+    def test_skipped_undefined_untested_statuses(self):
+        for status in ['skipped', 'undefined', 'untested']:
+            scenario_dict = {
+                'name': f'{status} test',
+                'status': status,
+                'duration': 0.0,
+                'tags': [],
+            }
+            result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
+            assert result.execution.status == 'skipped', (
+                f"Status '{status}' should map to 'skipped', got '{result.execution.status}'"
+            )
+
+
+class TestParseStepFromJson:
+    """Tests for parse_step_from_json(step_dict)."""
+
+    def test_basic_passed_step(self):
+        step_dict = {
+            'step_type': 'given',
+            'name': 'a user exists',
+            'line': 5,
+            'status': 'passed',
+            'duration': 0.5,
+        }
+        step = parse_step_from_json(step_dict)
+        assert step.data.keyword == 'given'
+        assert step.data.name == 'a user exists'
+        assert step.data.line == 5
+        assert step.execution.status == 'passed'
+        assert step.execution.duration == 500
+
+    def test_failed_step(self):
+        step_dict = {
+            'step_type': 'then',
+            'name': 'it should fail',
+            'line': 10,
+            'status': 'failed',
+            'duration': 0.1,
+        }
+        step = parse_step_from_json(step_dict)
+        assert step.execution.status == 'failed'
+
+    def test_error_step_maps_to_failed(self):
+        step_dict = {
+            'step_type': 'when',
+            'name': 'an error occurs',
+            'line': 7,
+            'status': 'error',
+            'duration': 0.2,
+        }
+        step = parse_step_from_json(step_dict)
+        assert step.execution.status == 'failed'
+
+    def test_undefined_step_maps_to_skipped(self):
+        step_dict = {
+            'step_type': 'given',
+            'name': 'an undefined step',
+            'line': 3,
+            'status': 'undefined',
+            'duration': 0.0,
+        }
+        step = parse_step_from_json(step_dict)
+        assert step.execution.status == 'skipped'
+
+    def test_step_with_timestamps(self):
+        step_dict = {
+            'step_type': 'given',
+            'name': 'timed step',
+            'line': 1,
+            'status': 'passed',
+            'duration': 1.0,
+            'start': 1700000000.0,
+            'stop': 1700000001.0,
+        }
+        step = parse_step_from_json(step_dict)
+        assert step.execution.start_time == 1700000000.0
+        assert step.execution.end_time == 1700000001.0
+
+    def test_step_defaults(self):
+        step_dict = {}
+        step = parse_step_from_json(step_dict)
+        assert step.data.keyword == 'given'
+        assert step.data.name == ''
+        assert step.data.line == 0
+        assert step.step_type == StepType.GHERKIN

--- a/qase-behave/tests/test_utils.py
+++ b/qase-behave/tests/test_utils.py
@@ -131,6 +131,10 @@ class TestParseScenarioFromJson:
         assert result.title == 'Login with valid credentials'
         assert result.execution.status == 'passed'
         assert result.execution.duration == 1500
+        # Without start/stop, end_time should be set and start_time calculated
+        assert result.execution.end_time > 0
+        assert result.execution.start_time > 0
+        assert result.execution.start_time <= result.execution.end_time
 
     def test_failed_scenario_with_error(self):
         scenario_dict = {
@@ -232,18 +236,18 @@ class TestParseScenarioFromJson:
         assert 'auth' in suite_titles
         assert 'login.feature' in suite_titles
 
-    def test_start_stop_timestamps(self):
+    def test_timestamps_calculated_from_duration(self):
+        """Timestamps should be calculated from current time and duration."""
         scenario_dict = {
             'name': 'Timed test',
             'status': 'passed',
-            'duration': 1.0,
+            'duration': 2.0,
             'tags': [],
-            'start': 1700000000.0,
-            'stop': 1700000001.0,
         }
         result = parse_scenario_from_json(scenario_dict, 'features/test.feature')
-        assert result.execution.start_time == 1700000000.0
-        assert result.execution.end_time == 1700000001.0
+        assert result.execution.end_time > 0
+        assert result.execution.start_time > 0
+        assert abs(result.execution.end_time - result.execution.start_time - 2.0) < 0.1
 
     def test_thread_from_worker_id(self):
         scenario_dict = {
@@ -287,6 +291,10 @@ class TestParseStepFromJson:
         assert step.data.line == 5
         assert step.execution.status == 'passed'
         assert step.execution.duration == 500
+        # Without start/stop, times should be calculated
+        assert step.execution.end_time > 0
+        assert step.execution.start_time > 0
+        assert step.execution.start_time <= step.execution.end_time
 
     def test_failed_step(self):
         step_dict = {
@@ -321,19 +329,19 @@ class TestParseStepFromJson:
         step = parse_step_from_json(step_dict)
         assert step.execution.status == 'skipped'
 
-    def test_step_with_timestamps(self):
+    def test_step_with_duration(self):
+        """Step timestamps calculated from current time and duration."""
         step_dict = {
             'step_type': 'given',
             'name': 'timed step',
             'line': 1,
             'status': 'passed',
             'duration': 1.0,
-            'start': 1700000000.0,
-            'stop': 1700000001.0,
         }
         step = parse_step_from_json(step_dict)
-        assert step.execution.start_time == 1700000000.0
-        assert step.execution.end_time == 1700000001.0
+        assert step.execution.end_time > 0
+        assert step.execution.start_time > 0
+        assert abs(step.execution.end_time - step.execution.start_time - 1.0) < 0.1
 
     def test_step_defaults(self):
         step_dict = {}


### PR DESCRIPTION
## Summary

- Add BehaveX parallel execution support to `qase-behave` via `--formatter` flag
- QaseFormatter implements `launch_json_formatter()` — BehaveX's post-execution formatter interface
- Full mapping of BehaveX consolidated JSON to Qase models: scenarios, steps, tags (`qase.id`, `qase.suite`, `qase.fields`, `qase.tags`, `qase.ignore`, `qase.project_id`), statuses, duration, error messages
- Lock file coordination (via `filelock`) for potential worker mode support
- Version bump 3.1.0 → 3.2.0

### Usage

```sh
behavex --formatter=qase.behave.formatter:QaseFormatter --parallel-processes=4 features/
```

### Known limitations

- `qase.attach()` / `qase.comment()` not supported in BehaveX mode (post-execution processing)
- Configuration only via env vars / `qase.config.json` (no `--define`)

## Test plan

- [x] 72 unit tests passing (18 new for JSON parsing, 6 new for formatter modes)
- [x] BehaveX single process + testops → run created successfully
- [x] BehaveX parallel (2 processes) + testops → run created successfully
- [x] BehaveX + report mode → 8 results in local JSON report
- [x] Standard behave + testops → no regressions
- [x] Lock files cleaned up after run