### PR TITLE
fix: relax urllib3 upper bound to <3.0.0 in API clients

### DIFF
--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "2.0.7"
+version = "2.0.8"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.9"
 dependencies = [
-    "urllib3 >= 2.5.0, < 2.7.0",
+    "urllib3 >= 2.5.0, < 3.0.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-client/requirements.txt
+++ b/qase-api-client/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.5.0, < 2.7.0
+urllib3 >= 2.5.0, < 3.0.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 lazy-imports >= 1, < 2

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "2.0.6"
+version = "2.0.7"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]
@@ -22,7 +22,7 @@ urls = {"Homepage" = "https://github.com/qase-tms/qase-python"}
 keywords = ["OpenAPI", "OpenAPI-Generator", "Qase.io TestOps API"]
 requires-python = ">=3.9"
 dependencies = [
-    "urllib3 >= 2.5.0, < 2.7.0",
+    "urllib3 >= 2.5.0, < 3.0.0",
     "python-dateutil",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/qase-api-v2-client/requirements.txt
+++ b/qase-api-v2-client/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.5.0, < 2.7.0
+urllib3 >= 2.5.0, < 3.0.0
 pydantic >= 2
 typing-extensions >= 4.7.1
 lazy-imports >= 1, < 2


### PR DESCRIPTION
## Summary

- Relaxes `urllib3` upper bound in both API clients from `< 2.7.0` to `< 3.0.0` so they can coexist with urllib3 2.7.x (and any future 2.x), matching the constraint convention used by `requests`.
- Bumps `qase-api-client` to **2.0.8** and `qase-api-v2-client` to **2.0.7**.

The previous cap caused a pip resolver conflict reported in #482: projects depending on both `qase-api-client==2.0.7` and `urllib3==2.7.0` (transitively required by `requests 2.33.0`) failed to install.

Fixes #482

## Test plan

- [ ] Install `qase-api-client==2.0.8` and `qase-api-v2-client==2.0.7` in a fresh env together with `requests==2.33.0` and `urllib3==2.7.0` — resolver succeeds.
- [ ] Existing tox suites for both API clients still pass across Python 3.9–3.13.