### PR TITLE
build: refuse PyPI packages uploaded less than 3 days ago

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,6 +2,11 @@ name: Python package
 
 on: [ push ]
 
+env:
+  # Supply-chain protection: refuse PyPI packages uploaded less than 3 days ago.
+  # Honored by pip>=26.1 (relative durations); silently ignored by older pip.
+  PIP_UPLOADED_PRIOR_TO: "P3D"
+
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -41,7 +46,10 @@ jobs:
       - name: Install dependencies
         if: steps.filter.outputs.changes == 'true'
         run: |
-          python -m pip install --upgrade pip
+          # Bootstrap with PIP_UPLOADED_PRIOR_TO unset: the seeded pip may be
+          # 26.0, which validates the value but only accepts ISO datetimes —
+          # the P3D form was added in 26.1.
+          env -u PIP_UPLOADED_PRIOR_TO python -m pip install --upgrade 'pip>=26.1'
           pip install tox tox-gh-actions
       - name: Run tox
         if: steps.filter.outputs.changes == 'true'
@@ -60,7 +68,7 @@ jobs:
 
       - name: Install reporters-validator
         run: |
-          python -m pip install --upgrade pip
+          env -u PIP_UPLOADED_PRIOR_TO python -m pip install --upgrade 'pip>=26.1'
           pip install git+https://github.com/qase-tms/reporters-validator.git
 
       - name: Download report schemas
@@ -69,6 +77,7 @@ jobs:
       - name: Validate Pytest reporter
         run: |
           python -m venv /tmp/venv-pytest
+          env -u PIP_UPLOADED_PRIOR_TO /tmp/venv-pytest/bin/python -m pip install --upgrade 'pip>=26.1'
           /tmp/venv-pytest/bin/pip install -q \
             ./qase-api-client ./qase-api-v2-client ./qase-python-commons ./qase-pytest
 
@@ -84,6 +93,7 @@ jobs:
       - name: Validate Behave reporter
         run: |
           python -m venv /tmp/venv-behave
+          env -u PIP_UPLOADED_PRIOR_TO /tmp/venv-behave/bin/python -m pip install --upgrade 'pip>=26.1'
           /tmp/venv-behave/bin/pip install -q \
             ./qase-api-client ./qase-api-v2-client ./qase-python-commons ./qase-behave
 
@@ -101,6 +111,7 @@ jobs:
       - name: Validate Robot Framework reporter
         run: |
           python -m venv /tmp/venv-robot
+          env -u PIP_UPLOADED_PRIOR_TO /tmp/venv-robot/bin/python -m pip install --upgrade 'pip>=26.1'
           /tmp/venv-robot/bin/pip install -q \
             ./qase-api-client ./qase-api-v2-client ./qase-python-commons ./qase-robotframework \
             robotframework
@@ -119,6 +130,7 @@ jobs:
       - name: Validate Tavern reporter
         run: |
           python -m venv /tmp/venv-tavern
+          env -u PIP_UPLOADED_PRIOR_TO /tmp/venv-tavern/bin/python -m pip install --upgrade 'pip>=26.1'
           /tmp/venv-tavern/bin/pip install -q \
             ./qase-api-client ./qase-api-v2-client ./qase-python-commons ./qase-tavern \
             tavern
@@ -161,7 +173,8 @@ jobs:
       - name: Install build dependencies
         if: contains(github.event.ref, matrix.prefix)
         run: |
-          python -m pip install --upgrade pip setuptools wheel build
+          env -u PIP_UPLOADED_PRIOR_TO python -m pip install --upgrade 'pip>=26.1'
+          pip install --upgrade setuptools wheel build
       - name: Build the package
         if: contains(github.event.ref, matrix.prefix)
         working-directory: ./${{ matrix.prefix }}

--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,10 @@
+# Supply-chain protection: refuse PyPI packages uploaded less than 3 days ago.
+# Defends against hijack attacks where a malicious version is published and
+# stays unnoticed for a few hours.
+#
+# Requires pip>=26.1 (relative durations). Older pip silently ignores this key.
+#
+# To activate for local development, point pip at this file:
+#   export PIP_CONFIG_FILE=$(git rev-parse --show-toplevel)/pip.conf
+[global]
+uploaded-prior-to = P3D


### PR DESCRIPTION
## Summary

Adds a 3-day cooldown on PyPI artifacts in CI as the analog of npm's
`min-release-age=3`. Defends against the recent wave of PyPI/npm
hijacks where attackers publish a malicious version and have a few
hours before maintainers notice.

## What changed

- `.github/workflows/pythonpackage.yml`:
  - New workflow-level `env: PIP_UPLOADED_PRIOR_TO: "P3D"` — propagates
    to every step and subprocess (tox, `python -m build`, integration
    test venvs).
  - Every explicit `pip install --upgrade pip` is now pinned to
    `pip>=26.1` (the version that learned the relative-duration form
    `P3D`).
  - Each of the 4 integration-test venvs (`pytest`, `behave`, `robot`,
    `tavern`) gets a `pip install --upgrade 'pip>=26.1'` before its
    real install, because `python -m venv` seeds whatever pip
    `ensurepip` bundles (older than 26.0 on every Python version in
    the matrix).
- `pip.conf`: new file at repo root. Developers can opt in locally
  with `export PIP_CONFIG_FILE=$(git rev-parse --show-toplevel)/pip.conf`.

## Why P3D and not larger / smaller

3 days was the requested value (mirrors `npm min-release-age=3`).
Roughly: long enough for the community to flag a hijack, short enough
to not block legitimate security releases of upstream deps.

## Bootstrap safety

The `python -m pip install --upgrade 'pip>=26.1'` step runs with the
env var already set under an older pip (the one `setup-python` seeds).
Older pip (≤25) does not error on unknown `PIP_*` env vars — see
[pypa/pip#8523](https://github.com/pypa/pip/issues/8523) — so the
bootstrap upgrade is safe.

## Known gap

The `test` job runs `tox`, and tox creates venvs via `virtualenv`
whose seeded pip is older than 26.1. Test dependencies (`pytest`,
`pytest-cov`, `pytest-bdd`) installed inside those venvs are therefore
**not** protected by the cooldown on this PR. The env var is
inherited but silently ignored.

Closing this gap fully would require either:
- per-package `[testenv]` `install_command` overrides across 7 tox
  configs (brittle shell quoting), or
- bumping virtualenv's bundled-wheel pin until it ships pip>=26.1, or
- migrating tox to `tox-uv`.

Deferred to a follow-up. The high-value paths (build/publish job and
integration-test job) are covered by this PR.

## Test plan

- [ ] CI green on the `test` matrix (Python 3.9–3.13 × 7 packages)
- [ ] CI green on `integration-test` (4 reporters validated)
- [ ] On the next release tag, `build-n-publish` produces a wheel
      with no <3-day-old transitive deps
- [ ] Local: `PIP_CONFIG_FILE=$(pwd)/pip.conf pip install --dry-run
      somepkg` honors the cooldown