### PR TITLE
make get_qase_ids public

### DIFF
--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -542,7 +542,7 @@ class QasePytestPlugin:
         return hasattr(report, 'wasxfail')
 
     @staticmethod
-    def _get_qase_ids(item) -> Union[None, List[int]]:
+    def get_qase_ids(item) -> Union[None, List[int]]:
         marker = item.get_closest_marker("qase_id")
         if marker is None:
             return None


### PR DESCRIPTION
We have a use case where we need to augment the qase test collection logic within our own pytest plugin. Being able to get the qase ids associated with a testcase is important for that use case. I don't see why this method needs to be protected so I've just modified the signature to make it public. If there's a specific reason this needs to be protected please let me know!