### PR TITLE
feat(qase-pytest): expose get_qase_ids as public API

### DIFF
--- a/qase-pytest/changelog.md
+++ b/qase-pytest/changelog.md
@@ -1,3 +1,11 @@
+# qase-pytest 8.3.0
+
+## What's new
+
+- Exposed `QasePytestPlugin.get_qase_ids(item)` as a public static method
+  so third-party pytest plugins can read the Qase IDs associated with a
+  pytest item without parsing the `qase_id` marker themselves.
+
 # qase-pytest 8.2.0
 
 ## What's new

--- a/qase-pytest/pyproject.toml
+++ b/qase-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-pytest"
-version = "8.2.0"
+version = "8.3.0"
 description = "Qase Pytest Plugin for Qase TestOps and Qase Report"
 readme = "README.md"
 keywords = ["qase", "pytest", "plugin", "testops", "report", "qase reporting", "test observability"]

--- a/qase-pytest/src/qase/pytest/plugin.py
+++ b/qase-pytest/src/qase/pytest/plugin.py
@@ -101,7 +101,7 @@ class QasePytestPlugin:
             new_items = []
             for item in items:
                 if item.get_closest_marker('qase_id'):
-                    ids = QasePytestPlugin._get_qase_ids(item)
+                    ids = QasePytestPlugin.get_qase_ids(item)
                     if any(id in self.execution_plan for id in ids):
                         new_items.append(item)
 
@@ -430,7 +430,7 @@ class QasePytestPlugin:
                         self.runtime.result.set_testops_project_mapping(project_code, testops_ids)
             else:
                 # Single project mode: use old testops_ids
-                self.runtime.result.testops_ids = QasePytestPlugin._get_qase_ids(item)
+                self.runtime.result.testops_ids = QasePytestPlugin.get_qase_ids(item)
         except (AttributeError, TypeError, ValueError):
             pass
 
@@ -542,7 +542,7 @@ class QasePytestPlugin:
         return hasattr(report, 'wasxfail')
 
     @staticmethod
-    def _get_qase_ids(item) -> Union[None, List[int]]:
+    def get_qase_ids(item) -> Union[None, List[int]]:
         marker = item.get_closest_marker("qase_id")
         if marker is None:
             return None

--- a/qase-pytest/tests/tests_qase_pytest/test_plugin.py
+++ b/qase-pytest/tests/tests_qase_pytest/test_plugin.py
@@ -59,37 +59,37 @@ def make_plugin():
 
 
 class TestGetQaseIds:
-    """Test _get_qase_ids static method edge cases."""
+    """Test get_qase_ids static method edge cases."""
 
     def test_returns_none_when_no_marker(self):
         item = make_mock_item()
-        assert QasePytestPlugin._get_qase_ids(item) is None
+        assert QasePytestPlugin.get_qase_ids(item) is None
 
     def test_returns_list_with_integer_id(self):
         marker = make_marker(id=42)
         item = make_mock_item(markers={"qase_id": marker})
-        assert QasePytestPlugin._get_qase_ids(item) == [42]
+        assert QasePytestPlugin.get_qase_ids(item) == [42]
 
     def test_returns_list_from_comma_separated_string(self):
         marker = make_marker(id="1,2,3")
         item = make_mock_item(markers={"qase_id": marker})
-        assert QasePytestPlugin._get_qase_ids(item) == [1, 2, 3]
+        assert QasePytestPlugin.get_qase_ids(item) == [1, 2, 3]
 
     def test_returns_none_when_id_kwarg_is_none(self):
         marker = make_marker(id=None)
         item = make_mock_item(markers={"qase_id": marker})
-        assert QasePytestPlugin._get_qase_ids(item) is None
+        assert QasePytestPlugin.get_qase_ids(item) is None
 
     def test_handles_string_with_spaces(self):
         marker = make_marker(id="10, 20, 30")
         item = make_mock_item(markers={"qase_id": marker})
-        assert QasePytestPlugin._get_qase_ids(item) == [10, 20, 30]
+        assert QasePytestPlugin.get_qase_ids(item) == [10, 20, 30]
 
     def test_raises_on_non_numeric_string(self):
         marker = make_marker(id="abc")
         item = make_mock_item(markers={"qase_id": marker})
         with pytest.raises(ValueError):
-            QasePytestPlugin._get_qase_ids(item)
+            QasePytestPlugin.get_qase_ids(item)
 
 
 class TestGetTitle:


### PR DESCRIPTION
## Summary

- Renames `QasePytestPlugin._get_qase_ids` to `get_qase_ids` so third-party pytest plugins can read the Qase IDs associated with a pytest item without parsing the `qase_id` marker themselves.
- Updates both internal call sites (`pytest_collection_modifyitems` filtering and single-project `testops_ids` assignment) so the rename does not break the plugin.
- Updates all `test_plugin.py` references and the `TestGetQaseIds` docstring.
- Bumps `qase-pytest` to `8.3.0` and adds a changelog entry.

Supersedes #487 (the original client PR only renamed the method definition, leaving the call sites and tests on the old name).

## Test plan

- [x] `pytest qase-pytest/tests` — all 110 tests pass locally on Python 3.12.
- [ ] CI green on all supported Python versions.