### PR TITLE
fix: compute robotframework step duration from total elapsed time

### DIFF
--- a/qase-robotframework/pyproject.toml
+++ b/qase-robotframework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-robotframework"
-version = "6.0.0"
+version = "6.0.1"
 description = "Qase Robot Framework Plugin"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-robotframework/src/qase/robotframework/listener.py
+++ b/qase-robotframework/src/qase/robotframework/listener.py
@@ -527,7 +527,7 @@ class Listener:
                 step_status = "failed"  # Keep as failed for steps, main test status is handled above
             step.execution.set_status(step_status)
             step.execution.start_time = result.body[i].start_time.timestamp()
-            step.execution.duration = result.body[i].elapsed_time.microseconds
+            step.execution.duration = int(result.body[i].elapsed_time.total_seconds() * 1000)
             step.execution.end_time = result.body[i].end_time.timestamp()
 
             if hasattr(result.body[i], "body"):

--- a/qase-robotframework/tests/tests_qaseio_robotframework/test_listener.py
+++ b/qase-robotframework/tests/tests_qaseio_robotframework/test_listener.py
@@ -4,6 +4,7 @@ Only tests static/class methods that do NOT require Robot Framework runtime
 or ConfigManager/QaseCoreReporter initialization.
 """
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -223,3 +224,66 @@ class TestStartSuiteHierarchy:
             listener.start_suite(account, MagicMock())
 
         assert listener.tests == {}
+
+
+class _FakeKeyword:
+    """Minimal Robot Framework keyword stand-in for __parse_steps.
+
+    The class name must be ``Keyword`` so listener's ``class_name == 'Keyword'``
+    branch is taken and ``elapsed_time`` is read from the real attribute.
+    """
+
+    def __init__(self, elapsed_seconds: float):
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        self.type = "KEYWORD"
+        self.name = "Some Keyword"
+        self.args = ()
+        self.status = "PASS"
+        self.start_time = start
+        self.elapsed_time = timedelta(seconds=elapsed_seconds)
+        self.end_time = start + self.elapsed_time
+        self.body = []
+
+
+Keyword = _FakeKeyword  # rename so __class__.__name__ == 'Keyword' inside listener
+
+
+class TestParseStepsDuration:
+    """Step duration must be elapsed time in milliseconds.
+
+    Regression for the bug where duration was taking ``timedelta.microseconds``
+    — the residual-microseconds field (0..999999) — instead of the full
+    elapsed milliseconds, inflating sub-second durations by ~1000x.
+    """
+
+    def _parse(self, listener, body_element):
+        result = MagicMock(spec=["body", "status"])
+        result.body = [body_element]
+        result.status = "PASS"
+        return listener._Listener__parse_steps(result)
+
+    @pytest.mark.parametrize(
+        "elapsed_seconds, expected_ms",
+        [
+            (0.0015, 1),        # 1.5 ms → 1 ms after int()
+            (0.5, 500),         # half a second → 500 ms (was 500000 before the fix)
+            (2.5, 2500),        # 2.5 s → 2500 ms (was 500000: only the residual µs field)
+            (12.345, 12345),    # double-digit seconds with sub-ms tail
+        ],
+    )
+    def test_duration_is_total_elapsed_milliseconds(self, elapsed_seconds, expected_ms):
+        listener = _bare_listener()
+        steps = self._parse(listener, Keyword(elapsed_seconds))
+
+        assert len(steps) == 1
+        assert steps[0].execution.duration == expected_ms
+
+    def test_start_and_end_time_round_trip(self):
+        listener = _bare_listener()
+        elapsed = 1.234
+        keyword = Keyword(elapsed)
+
+        steps = self._parse(listener, keyword)
+
+        assert steps[0].execution.start_time == keyword.start_time.timestamp()
+        assert steps[0].execution.end_time == keyword.end_time.timestamp()


### PR DESCRIPTION
## Summary

- `listener.__parse_steps` was setting `step.execution.duration` to `result.body[i].elapsed_time.microseconds` — the residual-microseconds field of a `timedelta` (0..999999), not the total length.
- Combined with the contract that `StepExecution.duration` is stored as **milliseconds** (`qase-python-commons/src/qase/commons/models/step.py:121`), this inflated every sub-second step by ~1000x. A 2.3 ms step appeared as 2.3 s; a 0.5 s step as 500 s; a 2.5 s step as 500 s (only the residual µs slot).
- Fix: `int(elapsed_time.total_seconds() * 1000)` so the value reflects real elapsed milliseconds.
- Bumps `qase-robotframework` to `6.0.1`.

## Test plan

- [x] Added unit tests for `__parse_steps` covering ms conversion at sub-millisecond, sub-second and multi-second durations plus a start/end time round-trip.
- [x] `pytest tests/tests_qaseio_robotframework/test_listener.py -v` → 18 passed locally (Python 3.12).
- [x] End-to-end verified against TestOps project DEVX with `examples/single/robot/tests/simple.robot`:
  - Before fix (run [#872](https://app.qase.io/run/DEVX/dashboard/872)): "Open Login Page" step shows `duration=2281` — rendered as 2.281 s (actual elapsed was 2.3 ms).
  - After fix (run [#873](https://app.qase.io/run/DEVX/dashboard/873)): same step `duration=1` (1 ms — matches actual elapsed).
- [ ] CI green on all supported Python versions.