### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/TestStepResult.md
+++ b/qase-api-client/docs/TestStepResult.md
@@ -7,8 +7,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **status** | **int** | 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress | [optional] 
 **position** | **int** |  | [optional] 
+**comment** | **str** | Comment left for the step. | [optional] 
+**start_time** | **int** | Unix timestamp of the step start time. | [optional] 
+**end_time** | **int** | Unix timestamp of the step end time. | [optional] 
+**duration_ms** | **int** | Step duration in milliseconds. | [optional] 
 **attachments** | [**List[Attachment]**](Attachment.md) |  | [optional] 
-**steps** | **List[object]** | Nested steps results will be here. The same structure is used for them for them. | [optional] 
+**steps** | [**List[TestStepResult]**](TestStepResult.md) | Nested steps results will be here. The same structure is used for them. | [optional] 
 
 ## Example
 

--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "2.0.9"
+version = "2.0.10"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-client/src/qase/api_client_v1/models/test_step_result.py
+++ b/qase-api-client/src/qase/api_client_v1/models/test_step_result.py
@@ -18,7 +18,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from qase.api_client_v1.models.attachment import Attachment
 from typing import Optional, Set
@@ -30,9 +30,13 @@ class TestStepResult(BaseModel):
     """ # noqa: E501
     status: Optional[StrictInt] = Field(default=None, description="1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress")
     position: Optional[StrictInt] = None
+    comment: Optional[StrictStr] = Field(default=None, description="Comment left for the step.")
+    start_time: Optional[StrictInt] = Field(default=None, description="Unix timestamp of the step start time.")
+    end_time: Optional[StrictInt] = Field(default=None, description="Unix timestamp of the step end time.")
+    duration_ms: Optional[StrictInt] = Field(default=None, description="Step duration in milliseconds.")
     attachments: Optional[List[Attachment]] = None
-    steps: Optional[List[Dict[str, Any]]] = Field(default=None, description="Nested steps results will be here. The same structure is used for them for them.")
-    __properties: ClassVar[List[str]] = ["status", "position", "attachments", "steps"]
+    steps: Optional[List[TestStepResult]] = Field(default=None, description="Nested steps results will be here. The same structure is used for them.")
+    __properties: ClassVar[List[str]] = ["status", "position", "comment", "start_time", "end_time", "duration_ms", "attachments", "steps"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -80,6 +84,28 @@ class TestStepResult(BaseModel):
                 if _item_attachments:
                     _items.append(_item_attachments.to_dict())
             _dict['attachments'] = _items
+        # override the default output from pydantic by calling `to_dict()` of each item in steps (list)
+        _items = []
+        if self.steps:
+            for _item_steps in self.steps:
+                if _item_steps:
+                    _items.append(_item_steps.to_dict())
+            _dict['steps'] = _items
+        # set to None if start_time (nullable) is None
+        # and model_fields_set contains the field
+        if self.start_time is None and "start_time" in self.model_fields_set:
+            _dict['start_time'] = None
+
+        # set to None if end_time (nullable) is None
+        # and model_fields_set contains the field
+        if self.end_time is None and "end_time" in self.model_fields_set:
+            _dict['end_time'] = None
+
+        # set to None if duration_ms (nullable) is None
+        # and model_fields_set contains the field
+        if self.duration_ms is None and "duration_ms" in self.model_fields_set:
+            _dict['duration_ms'] = None
+
         return _dict
 
     @classmethod
@@ -94,9 +120,15 @@ class TestStepResult(BaseModel):
         _obj = cls.model_validate({
             "status": obj.get("status"),
             "position": obj.get("position"),
+            "comment": obj.get("comment"),
+            "start_time": obj.get("start_time"),
+            "end_time": obj.get("end_time"),
+            "duration_ms": obj.get("duration_ms"),
             "attachments": [Attachment.from_dict(_item) for _item in obj["attachments"]] if obj.get("attachments") is not None else None,
-            "steps": obj.get("steps")
+            "steps": [TestStepResult.from_dict(_item) for _item in obj["steps"]] if obj.get("steps") is not None else None
         })
         return _obj
 
+# TODO: Rewrite to not use raise_errors
+TestStepResult.model_rebuild(raise_errors=False)
 


### PR DESCRIPTION
## Summary

Updated the v1 API client to the latest OpenAPI specification.

### Targets updated
- v1 (`qase-api-client`): 2.0.9 → 2.0.10

### Changes
`TestStepResult` model now includes the fields actually returned by the public API v1:
- `comment` (string)
- `start_time`, `end_time`, `duration_ms` (nullable)
- nested `steps` now typed recursively as `List[TestStepResult]`

### Protected files (skipped)
- `api_client.py`

### Warnings
None