### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/CasesApi.md
+++ b/qase-api-client/docs/CasesApi.md
@@ -589,10 +589,10 @@ with qase.api_client_v1.ApiClient(configuration) as api_client:
     suite_id = 56 # int | ID of test suite. (optional)
     severity = 'severity_example' # str | A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial  (optional)
     priority = 'priority_example' # str | A list of priority values separated by comma. Possible values: undefined, high, medium, low  (optional)
-    type = 'type_example' # str | A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance  (optional)
-    behavior = 'behavior_example' # str | A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive  (optional)
-    automation = 'automation_example' # str | A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated  (optional)
-    status = 'status_example' # str | A list of values separated by comma. Possible values: actual, draft deprecated  (optional)
+    type = 'type_example' # str | A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance  (optional)
+    behavior = 'behavior_example' # str | A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive  (optional)
+    automation = 'automation_example' # str | A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated  (optional)
+    status = 'status_example' # str | A list of values separated by comma. Possible values: actual, draft, deprecated  (optional)
     external_issues_type = 'external_issues_type_example' # str | An integration type.  (optional)
     external_issues_ids = ['external_issues_ids_example'] # List[str] | A list of issue IDs. (optional)
     include = 'include_example' # str | A list of entities to include in response separated by comma. Possible values: external_issues.  (optional)
@@ -621,10 +621,10 @@ Name | Type | Description  | Notes
  **suite_id** | **int**| ID of test suite. | [optional] 
  **severity** | **str**| A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial  | [optional] 
  **priority** | **str**| A list of priority values separated by comma. Possible values: undefined, high, medium, low  | [optional] 
- **type** | **str**| A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance  | [optional] 
- **behavior** | **str**| A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive  | [optional] 
- **automation** | **str**| A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated  | [optional] 
- **status** | **str**| A list of values separated by comma. Possible values: actual, draft deprecated  | [optional] 
+ **type** | **str**| A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance  | [optional] 
+ **behavior** | **str**| A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive  | [optional] 
+ **automation** | **str**| A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated  | [optional] 
+ **status** | **str**| A list of values separated by comma. Possible values: actual, draft, deprecated  | [optional] 
  **external_issues_type** | **str**| An integration type.  | [optional] 
  **external_issues_ids** | [**List[str]**](str.md)| A list of issue IDs. | [optional] 
  **include** | **str**| A list of entities to include in response separated by comma. Possible values: external_issues.  | [optional] 

--- a/qase-api-client/docs/TestStepCreate.md
+++ b/qase-api-client/docs/TestStepCreate.md
@@ -6,6 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **action** | **str** | Step action text. Used for classic steps. For gherkin steps, use the \&quot;value\&quot; property instead. | [optional] 
+**shared** | **str** | Hash of an existing shared step to insert at this position. | [optional] 
 **expected_result** | **str** |  | [optional] 
 **data** | **str** |  | [optional] 
 **value** | **str** | Gherkin scenario text. Used when steps_type is \&quot;gherkin\&quot;. Example: \&quot;Given a user exists\\nWhen they log in\\nThen they see the dashboard\&quot; | [optional] 

--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "2.0.11"
+version = "2.0.12"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-client/src/qase/api_client_v1/api/cases_api.py
+++ b/qase-api-client/src/qase/api_client_v1/api/cases_api.py
@@ -1889,10 +1889,10 @@ class CasesApi:
         suite_id: Annotated[Optional[StrictInt], Field(description="ID of test suite.")] = None,
         severity: Annotated[Optional[StrictStr], Field(description="A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial ")] = None,
         priority: Annotated[Optional[StrictStr], Field(description="A list of priority values separated by comma. Possible values: undefined, high, medium, low ")] = None,
-        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance ")] = None,
-        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive ")] = None,
-        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated ")] = None,
-        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft deprecated ")] = None,
+        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance ")] = None,
+        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive ")] = None,
+        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated ")] = None,
+        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft, deprecated ")] = None,
         external_issues_type: Annotated[Optional[StrictStr], Field(description="An integration type. ")] = None,
         external_issues_ids: Annotated[Optional[List[StrictStr]], Field(description="A list of issue IDs.")] = None,
         include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
@@ -1927,13 +1927,13 @@ class CasesApi:
         :type severity: str
         :param priority: A list of priority values separated by comma. Possible values: undefined, high, medium, low 
         :type priority: str
-        :param type: A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance 
+        :param type: A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance 
         :type type: str
-        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive 
+        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive 
         :type behavior: str
-        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated 
+        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated 
         :type automation: str
-        :param status: A list of values separated by comma. Possible values: actual, draft deprecated 
+        :param status: A list of values separated by comma. Possible values: actual, draft, deprecated 
         :type status: str
         :param external_issues_type: An integration type. 
         :type external_issues_type: str
@@ -2018,10 +2018,10 @@ class CasesApi:
         suite_id: Annotated[Optional[StrictInt], Field(description="ID of test suite.")] = None,
         severity: Annotated[Optional[StrictStr], Field(description="A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial ")] = None,
         priority: Annotated[Optional[StrictStr], Field(description="A list of priority values separated by comma. Possible values: undefined, high, medium, low ")] = None,
-        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance ")] = None,
-        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive ")] = None,
-        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated ")] = None,
-        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft deprecated ")] = None,
+        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance ")] = None,
+        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive ")] = None,
+        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated ")] = None,
+        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft, deprecated ")] = None,
         external_issues_type: Annotated[Optional[StrictStr], Field(description="An integration type. ")] = None,
         external_issues_ids: Annotated[Optional[List[StrictStr]], Field(description="A list of issue IDs.")] = None,
         include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
@@ -2056,13 +2056,13 @@ class CasesApi:
         :type severity: str
         :param priority: A list of priority values separated by comma. Possible values: undefined, high, medium, low 
         :type priority: str
-        :param type: A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance 
+        :param type: A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance 
         :type type: str
-        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive 
+        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive 
         :type behavior: str
-        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated 
+        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated 
         :type automation: str
-        :param status: A list of values separated by comma. Possible values: actual, draft deprecated 
+        :param status: A list of values separated by comma. Possible values: actual, draft, deprecated 
         :type status: str
         :param external_issues_type: An integration type. 
         :type external_issues_type: str
@@ -2147,10 +2147,10 @@ class CasesApi:
         suite_id: Annotated[Optional[StrictInt], Field(description="ID of test suite.")] = None,
         severity: Annotated[Optional[StrictStr], Field(description="A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial ")] = None,
         priority: Annotated[Optional[StrictStr], Field(description="A list of priority values separated by comma. Possible values: undefined, high, medium, low ")] = None,
-        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance ")] = None,
-        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive ")] = None,
-        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated ")] = None,
-        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft deprecated ")] = None,
+        type: Annotated[Optional[StrictStr], Field(description="A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance ")] = None,
+        behavior: Annotated[Optional[StrictStr], Field(description="A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive ")] = None,
+        automation: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated ")] = None,
+        status: Annotated[Optional[StrictStr], Field(description="A list of values separated by comma. Possible values: actual, draft, deprecated ")] = None,
         external_issues_type: Annotated[Optional[StrictStr], Field(description="An integration type. ")] = None,
         external_issues_ids: Annotated[Optional[List[StrictStr]], Field(description="A list of issue IDs.")] = None,
         include: Annotated[Optional[StrictStr], Field(description="A list of entities to include in response separated by comma. Possible values: external_issues. ")] = None,
@@ -2185,13 +2185,13 @@ class CasesApi:
         :type severity: str
         :param priority: A list of priority values separated by comma. Possible values: undefined, high, medium, low 
         :type priority: str
-        :param type: A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance 
+        :param type: A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance 
         :type type: str
-        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive 
+        :param behavior: A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive 
         :type behavior: str
-        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated 
+        :param automation: A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated 
         :type automation: str
-        :param status: A list of values separated by comma. Possible values: actual, draft deprecated 
+        :param status: A list of values separated by comma. Possible values: actual, draft, deprecated 
         :type status: str
         :param external_issues_type: An integration type. 
         :type external_issues_type: str

--- a/qase-api-client/src/qase/api_client_v1/models/test_step_create.py
+++ b/qase-api-client/src/qase/api_client_v1/models/test_step_create.py
@@ -28,13 +28,14 @@ class TestStepCreate(BaseModel):
     TestStepCreate
     """ # noqa: E501
     action: Optional[StrictStr] = Field(default=None, description="Step action text. Used for classic steps. For gherkin steps, use the \"value\" property instead.")
+    shared: Optional[StrictStr] = Field(default=None, description="Hash of an existing shared step to insert at this position.")
     expected_result: Optional[StrictStr] = None
     data: Optional[StrictStr] = None
     value: Optional[StrictStr] = Field(default=None, description="Gherkin scenario text. Used when steps_type is \"gherkin\". Example: \"Given a user exists\\nWhen they log in\\nThen they see the dashboard\"")
     position: Optional[StrictInt] = None
     attachments: Optional[List[StrictStr]] = Field(default=None, description="A list of Attachment hashes.")
     steps: Optional[List[Dict[str, Any]]] = Field(default=None, description="Nested steps may be passed here. Use same structure for them.")
-    __properties: ClassVar[List[str]] = ["action", "expected_result", "data", "value", "position", "attachments", "steps"]
+    __properties: ClassVar[List[str]] = ["action", "shared", "expected_result", "data", "value", "position", "attachments", "steps"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,6 +89,7 @@ class TestStepCreate(BaseModel):
 
         _obj = cls.model_validate({
             "action": obj.get("action"),
+            "shared": obj.get("shared"),
             "expected_result": obj.get("expected_result"),
             "data": obj.get("data"),
             "value": obj.get("value"),


### PR DESCRIPTION
Regenerated the v1 API client from the latest OpenAPI spec. Adds the `shared` field to `TestStepCreate`, which links a test case step to an existing shared step by hash.

qase-api-client: 2.0.11 → 2.0.12