### PR TITLE
fix: lower max batch size from 2000 to 200

### DIFF
--- a/qase-pytest/docs/UPGRADE.md
+++ b/qase-pytest/docs/UPGRADE.md
@@ -17,7 +17,7 @@ In v5, two configuration options defined how the reporter was uploading results 
 `testops.bulk` and `testops.chunk`.
 
 In v6, reporter always sends results in portions, called batches.
-Default batch size is 200, and can be set to anything from 1 to 2000.
+Default batch size is 200, and can be set to anything from 1 to 200.
 Update the config in the following way:
 
 ```diff

--- a/qase-python-commons/src/qase/commons/models/config/batch.py
+++ b/qase-python-commons/src/qase/commons/models/config/batch.py
@@ -8,6 +8,6 @@ class BatchConfig(BaseModel):
         self.size = 200
 
     def set_size(self, size: int):
-        if size > 2000 or size == 0:
-            raise ValueError("Batch size should be greater than 0 and less than 2000")
+        if size > 200 or size == 0:
+            raise ValueError("Batch size should be greater than 0 and no greater than 200")
         self.size = size

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -32,7 +32,7 @@ class QaseTestOps:
         self.complete_after_run = self.config.testops.run.complete
         self.environment = None
 
-        self.batch_size = min(2000, max(1, int(self.config.testops.batch.size or DEFAULT_BATCH_SIZE)))
+        self.batch_size = min(200, max(1, int(self.config.testops.batch.size or DEFAULT_BATCH_SIZE)))
         self.send_semaphore = threading.Semaphore(DEFAULT_THREAD_COUNT)  # Semaphore to limit concurrent sends
         self.lock = threading.Lock()
         self.count_running_threads = 0

--- a/qase-python-commons/src/qase/commons/reporters/testops_multi.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops_multi.py
@@ -22,7 +22,7 @@ class QaseTestOpsMulti:
         self.client = client
 
         self.multi_config = config.testops_multi
-        self.batch_size = min(2000, max(1, int(self.config.testops.batch.size or DEFAULT_BATCH_SIZE)))
+        self.batch_size = min(200, max(1, int(self.config.testops.batch.size or DEFAULT_BATCH_SIZE)))
         self.send_semaphore = threading.Semaphore(DEFAULT_THREAD_COUNT)
         self.lock = threading.Lock()
         self.count_running_threads = 0

--- a/qase-robotframework/docs/UPGRADE.md
+++ b/qase-robotframework/docs/UPGRADE.md
@@ -40,7 +40,7 @@ In v3, two configuration options defined how the reporter was uploading results 
 `testops.bulk` and `testops.chunk`.
 
 In v3, reporter always sends results in portions, called batches.
-Default batch size is 200, and can be set to anything from 1 to 2000.
+Default batch size is 200, and can be set to anything from 1 to 200.
 Update the config in the following way:
 
 ```diff


### PR DESCRIPTION
Lowers the batch-size ceiling in `qase-python-commons` from 2000 to 200.

## What changed

- `qase-python-commons/src/qase/commons/models/config/batch.py` — `set_size` rejects a size above 200. The old message said "less than 2000" while the check tested `> 2000`; the new wording matches the check.
- `qase-python-commons/src/qase/commons/reporters/testops.py` and `testops_multi.py` — clamp with `min(200, ...)`.
- `qase-pytest/docs/UPGRADE.md` and `qase-robotframework/docs/UPGRADE.md` — state the 1-200 range.

The default stays 200, so no user on defaults is affected.

## Tests

`qase-python-commons` suite: 243 passed, 4 skipped.

## Why

TMS-196 lowers the bulk-results cap from 2000 to 200 results per request. Very large batches arrive as a single spike in the result-processing queue and delay processing for every customer, including runs that report a handful of results at a time. Fewer than 1% of batches exceed 200 today.

This PR removes the stale 2000 from this repository. Server-side enforcement lands separately in the `app` and `specs` repositories.

## Flags for the reviewer

1. **Missing clamps.** Only Java and Python validate the configured batch size at all. JavaScript, C#, Go, qasectl and PHP pass a configured value straight to the API, so a user who set 500 gets an HTTP 413 and lost results instead of a local warning. Adding a clamp is a separate call — your decision whether and when.
2. **Generated API clients still say 2000.** The `maxItems: 2000` constraint and the "more than 2,000 results" endpoint description are generated from the v1 OpenAPI spec into every client (`qase-api-client`, `qase-php-client`, and the vendored clients in this and the other language repos). They change by regenerating from the spec, not by hand. Note `qase-javascript` carries two generated trees (`qase-api-client/` and `qaseio/src/generated/`), so a partial regeneration leaves one stale.

Full cross-repo inventory of every mention, including an org-wide sweep of all 163 `qase-tms` repositories, is available on request.
