### PR TITLE
chore: bump qase-python-commons to 5.1.3

### DIFF
--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-python-commons@5.1.3
+
+## What's new
+
+- Lowered the maximum batch size from 2000 to 200 results per request, matching the new bulk-results API cap. `BatchConfig.set_size` now rejects a size above 200, and both TestOps reporters clamp the configured size with `min(200, ...)`. The default stays 200, so setups on defaults are unaffected.
+
 # qase-python-commons@5.1.2
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "5.1.2"
+version = "5.1.3"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]


### PR DESCRIPTION
Patch release for the batch-size change merged in #507.

## What changed

- `qase-python-commons/pyproject.toml` — version 5.1.2 → 5.1.3
- `qase-python-commons/changelog.md` — entry for 5.1.3

## Why only qase-python-commons

#507 touched five files. The three code files all live in `qase-python-commons` (`models/config/batch.py`, `reporters/testops.py`, `reporters/testops_multi.py`). The `qase-pytest` and `qase-robotframework` changes were `docs/UPGRADE.md` edits only, so those packages ship no new code and are not bumped.

The `qase-python-commons~=5.1.2` pin in `qase-pytest/pyproject.toml` already accepts 5.1.3 (`~=5.1.2` means `>=5.1.2, ==5.1.*`), so no dependent pins need updating.

## Tests

No code changes in this PR — only version metadata and changelog. The batch-size change itself was verified in #507 (243 passed, 4 skipped).