### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/ResultsApi.md
+++ b/qase-api-client/docs/ResultsApi.md
@@ -110,7 +110,7 @@ Bulk create test run result
 
 This method allows to create a lot of test run result at once.
 
-If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.
+If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.
 
 If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage.
 

--- a/qase-api-client/pyproject.toml
+++ b/qase-api-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-client"
-version = "2.0.13"
+version = "2.0.14"
 description = "Qase TestOps API V1 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-client/src/qase/api_client_v1/api/results_api.py
+++ b/qase-api-client/src/qase/api_client_v1/api/results_api.py
@@ -389,7 +389,7 @@ class ResultsApi:
     ) -> BaseResponse:
         """Bulk create test run result
 
-        This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
 
         :param code: Code of project, where to search entities. (required)
         :type code: str
@@ -471,7 +471,7 @@ class ResultsApi:
     ) -> ApiResponse[BaseResponse]:
         """Bulk create test run result
 
-        This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
 
         :param code: Code of project, where to search entities. (required)
         :type code: str
@@ -553,7 +553,7 @@ class ResultsApi:
     ) -> RESTResponseType:
         """Bulk create test run result
 
-        This method allows to create a lot of test run result at once.  If you try to send more than 2,000 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
+        This method allows to create a lot of test run result at once.  If you try to send more than 200 results in a single bulk request, you will receive an error with code 413 - Payload Too Large.  If there is no free space left in your team account, when attempting to upload an attachment, e.g., through reporters, you will receive an error with code 507 - Insufficient Storage. 
 
         :param code: Code of project, where to search entities. (required)
         :type code: str

--- a/qase-api-client/src/qase/api_client_v1/models/result_create_bulk.py
+++ b/qase-api-client/src/qase/api_client_v1/models/result_create_bulk.py
@@ -29,7 +29,7 @@ class ResultCreateBulk(BaseModel):
     """
     ResultCreateBulk
     """ # noqa: E501
-    results: Annotated[List[ResultCreate], Field(max_length=2000)]
+    results: Annotated[List[ResultCreate], Field(max_length=200)]
     __properties: ClassVar[List[str]] = ["results"]
 
     model_config = ConfigDict(

--- a/qase-api-v2-client/docs/ResultExecution.md
+++ b/qase-api-v2-client/docs/ResultExecution.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **status** | **str** | Can have the following values passed, failed, blocked, skipped, invalid + custom statuses | 
 **duration** | **int** | Duration of the test execution in milliseconds. | [optional] 
 **stacktrace** | **str** |  | [optional] 
+**error_context** | **str** | Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints. | [optional] 
 **thread** | **str** |  | [optional] 
 
 ## Example

--- a/qase-api-v2-client/docs/ResultsApi.md
+++ b/qase-api-v2-client/docs/ResultsApi.md
@@ -188,6 +188,7 @@ Name | Type | Description  | Notes
 **401** | Unauthorized |  -  |
 **403** | Forbidden |  -  |
 **404** | Not Found |  -  |
+**413** | Payload Too Large. Returned when the request contains more than 200 results, or when the combined length of &#x60;execution.error_context&#x60; across the batch exceeds 4194304 characters. In both cases the whole batch is rejected — no results are created.  |  -  |
 **422** | Unprocessable Entity |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/qase-api-v2-client/pyproject.toml
+++ b/qase-api-v2-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-api-v2-client"
-version = "2.0.7"
+version = "2.0.8"
 description = "Qase TestOps API V2 client for Python"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-api-v2-client/src/qase/api_client_v2/api/results_api.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/api/results_api.py
@@ -426,6 +426,7 @@ class ResultsApi:
             '401': None,
             '403': None,
             '404': None,
+            '413': None,
             '422': None,
         }
         response_data = self.api_client.call_api(
@@ -506,6 +507,7 @@ class ResultsApi:
             '401': None,
             '403': None,
             '404': None,
+            '413': None,
             '422': None,
         }
         response_data = self.api_client.call_api(
@@ -586,6 +588,7 @@ class ResultsApi:
             '401': None,
             '403': None,
             '404': None,
+            '413': None,
             '422': None,
         }
         response_data = self.api_client.call_api(

--- a/qase-api-v2-client/src/qase/api_client_v2/models/result_execution.py
+++ b/qase-api-v2-client/src/qase/api_client_v2/models/result_execution.py
@@ -32,8 +32,9 @@ class ResultExecution(BaseModel):
     status: StrictStr = Field(description="Can have the following values passed, failed, blocked, skipped, invalid + custom statuses")
     duration: Optional[StrictInt] = Field(default=None, description="Duration of the test execution in milliseconds.")
     stacktrace: Optional[StrictStr] = None
+    error_context: Optional[StrictStr] = Field(default=None, description="Free-form failure context captured by the reporter. For Playwright this is the content of error-context.md (test info, error details, page snapshot), so it may include rendered page content. Stored verbatim so it can be copied as raw text. Values longer than 262144 characters are silently truncated by Qase and the request still succeeds. Write-only — not returned by the result read endpoints.")
     thread: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["start_time", "end_time", "status", "duration", "stacktrace", "thread"]
+    __properties: ClassVar[List[str]] = ["start_time", "end_time", "status", "duration", "stacktrace", "error_context", "thread"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -94,6 +95,11 @@ class ResultExecution(BaseModel):
         if self.stacktrace is None and "stacktrace" in self.model_fields_set:
             _dict['stacktrace'] = None
 
+        # set to None if error_context (nullable) is None
+        # and model_fields_set contains the field
+        if self.error_context is None and "error_context" in self.model_fields_set:
+            _dict['error_context'] = None
+
         # set to None if thread (nullable) is None
         # and model_fields_set contains the field
         if self.thread is None and "thread" in self.model_fields_set:
@@ -116,6 +122,7 @@ class ResultExecution(BaseModel):
             "status": obj.get("status"),
             "duration": obj.get("duration"),
             "stacktrace": obj.get("stacktrace"),
+            "error_context": obj.get("error_context"),
             "thread": obj.get("thread")
         })
         return _obj


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification

### Targets updated:
- `qase-api-client` (v1): 2.0.13 → 2.0.14 — `ResultCreateBulk.results` max length lowered from 2000 to 200, endpoint docs updated accordingly
- `qase-api-v2-client` (v2): 2.0.7 → 2.0.8 — added the `execution.error_context` field to `ResultExecution` and documented the `413 Payload Too Large` response (more than 200 results, or oversized `error_context`)

### Protected files (skipped):
- `api_client.py` (both packages), `models/configuration.py`, `models/configuration_group.py`, package `__init__.py` files, `docs/Configuration.md`

### Warnings:
None