### PR TITLE
fix: retry result uploads instead of silently losing them (#504)

### DIFF
--- a/qase-python-commons/README.md
+++ b/qase-python-commons/README.md
@@ -30,6 +30,7 @@ Core library for all Qase Python reporters. Contains the complete configuration 
   - [Status Filtering](#status-filtering)
   - [External Links](#external-links)
   - [Test Run Configurations](#test-run-configurations)
+  - [Upload Reliability](#upload-reliability)
 
 ---
 
@@ -102,6 +103,9 @@ The reporter mode is set via the `mode` option:
 |-------------|-------------|---------------------|---------|----------|
 | API token | `testops.api.token` | `QASE_TESTOPS_API_TOKEN` | — | Yes* |
 | API host | `testops.api.host` | `QASE_TESTOPS_API_HOST` | `qase.io` | No |
+| Request timeout, seconds | `testops.api.timeout` | `QASE_TESTOPS_API_TIMEOUT` | `30` | No |
+| Upload attempts | `testops.api.retries` | `QASE_TESTOPS_API_RETRIES` | `3` | No |
+| Retry backoff base, seconds | `testops.api.retryBackoff` | `QASE_TESTOPS_API_RETRY_BACKOFF` | `2` | No |
 | Project code | `testops.project` | `QASE_TESTOPS_PROJECT` | — | Yes* |
 | Test run ID | `testops.run.id` | `QASE_TESTOPS_RUN_ID` | — | No |
 | Test run title | `testops.run.title` | `QASE_TESTOPS_RUN_TITLE` | `Automated run <date>` | No |
@@ -261,6 +265,9 @@ export QASE_TESTOPS_API_TOKEN="<token>"
 export QASE_TESTOPS_PROJECT="DEMO"
 export QASE_TESTOPS_RUN_TITLE="Automated Run"
 export QASE_TESTOPS_RUN_COMPLETE="true"
+export QASE_TESTOPS_API_TIMEOUT="30"
+export QASE_TESTOPS_API_RETRIES="3"
+export QASE_TESTOPS_API_RETRY_BACKOFF="2"
 
 # Pytest
 export QASE_PYTEST_CAPTURE_LOGS="true"
@@ -369,6 +376,44 @@ Creates or finds configurations in Qase TestOps:
         { "name": "os", "value": "linux" }
       ],
       "createIfNotExists": true
+    }
+  }
+}
+```
+
+### Upload Reliability
+
+Results are uploaded in batches from background threads. A batch that fails on
+a transient error is retried rather than dropped.
+
+| Setting | Meaning |
+|---------|---------|
+| `testops.api.timeout` | Per-request timeout in seconds. Without it a stalled connection blocks the session at teardown. |
+| `testops.api.retries` | Total attempts per batch, not retries on top of the first. `3` means three tries; `0` sends once and never retries. |
+| `testops.api.retryBackoff` | Base of the exponential delay: attempt *n* waits `retryBackoff ** n` seconds. |
+
+Retried: connection resets, timeouts and other transport failures, plus HTTP
+408, 429 and 5xx. Not retried: 400, 401, 403, 404, 413, 422 and 507 — a second
+attempt fails identically and only adds load.
+
+When a 429 carries a `Retry-After` header, that value replaces the computed
+backoff. Qase sends roughly 60 seconds, so a run that hits the rate limit takes
+longer to finish rather than losing the batch.
+
+**If a batch cannot be delivered after all attempts**, the reporter logs an
+error naming how many results were lost and **does not mark the run complete**.
+An open run is the signal that its data is incomplete; a completed run over
+partial results would look trustworthy and not be. In `testops_multi` mode this
+is per project — one project's failure does not stop the others completing.
+
+```json
+{
+  "testops": {
+    "api": {
+      "token": "<token>",
+      "timeout": 30,
+      "retries": 3,
+      "retryBackoff": 2
     }
   }
 }

--- a/qase-python-commons/changelog.md
+++ b/qase-python-commons/changelog.md
@@ -1,3 +1,13 @@
+# qase-python-commons@5.1.4
+
+## What's new
+
+- Fixed silent loss of test results when a batch upload fails ([#504](https://github.com/qase-tms/qase-python/issues/504)). The reporter discarded its only copy of a batch when it started the upload thread rather than when the server confirmed it, so a connection reset made those results cease to exist while the run was still marked complete and the process exited 0. Failed batches are now retried; if a batch still cannot be delivered, the reporter logs an error naming how many results were lost and leaves the run open instead of completing it. In `testops_multi` mode this is tracked per project, so one project's failure does not stop the others completing.
+- `ResultCreate.id` is now sent on bulk upload. The v2 API uses it as an idempotency key, and the value was already generated on every result but dropped when building the payload. Without it a retried batch would create duplicate results.
+- Added `testops.api.timeout` (default `30`), `testops.api.retries` (default `3`) and `testops.api.retryBackoff` (default `2`), with `QASE_TESTOPS_API_TIMEOUT`, `QASE_TESTOPS_API_RETRIES` and `QASE_TESTOPS_API_RETRY_BACKOFF` overrides. Retries cover transport failures and HTTP 408/429/5xx, honour `Retry-After`, and never fire on 400/401/403/404/413/422/507. `retries` counts total attempts, so `0` sends once without retrying.
+- Set an explicit request timeout on result uploads. There was none, so a connection that stalled rather than failed hung the session at teardown until CI killed the job.
+- Pinned urllib3's own retry policy off (`Configuration.retries = 0`). It was left unset, so urllib3's defaults applied and would have multiplied with the new application-level retry.
+
 # qase-python-commons@5.1.3
 
 ## What's new

--- a/qase-python-commons/pyproject.toml
+++ b/qase-python-commons/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qase-python-commons"
-version = "5.1.3"
+version = "5.1.4"
 description = "A library for Qase TestOps and Qase Report"
 readme = "README.md"
 authors = [{name = "Qase Team", email = "support@qase.io"}]

--- a/qase-python-commons/src/qase/commons/client/api_v1_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v1_client.py
@@ -26,6 +26,9 @@ class ApiV1Client(BaseApiClient):
             configuration = Configuration()
             configuration.api_key['TokenAuth'] = self.config.testops.api.token
             configuration.ssl_ca_cert = certifi.where()
+            # See the note in ApiV2Client: urllib3's default retry policy is
+            # pinned off so it cannot multiply with the application-level one.
+            configuration.retries = 0
             host = self.config.testops.api.host
             if host == 'qase.io':
                 configuration.host = f'https://api.{host}/v1'

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -158,6 +158,7 @@ class ApiV2Client(ApiV1Client):
                 result.params[key] = "empty"
 
         result_model_v2 = ResultCreate(
+            id=result.id,
             title=result.get_title(),
             signature=result.signature,
             testops_ids=result.get_testops_ids(),

--- a/qase-python-commons/src/qase/commons/client/api_v2_client.py
+++ b/qase-python-commons/src/qase/commons/client/api_v2_client.py
@@ -36,6 +36,11 @@ class ApiV2Client(ApiV1Client):
             configuration = Configuration()
             configuration.api_key['TokenAuth'] = self.config.testops.api.token
             configuration.ssl_ca_cert = certifi.where()
+            # Pin urllib3's own retry policy off: the reporter retries at the
+            # application level, and leaving this at None lets urllib3's
+            # defaults multiply with ours -- a 3-attempt policy would issue
+            # 9 requests, the opposite of what is wanted on a 429.
+            configuration.retries = 0
             host = self.config.testops.api.host
             if host == 'qase.io':
                 configuration.host = f'https://api.{host}/v2'
@@ -131,7 +136,8 @@ class ApiV2Client(ApiV1Client):
         run_id_int = int(run_id) if isinstance(run_id, str) else run_id
         self.logger.log_debug(f"Sending results for run {run_id_int}: {results_to_send}")
         api_results.create_results_v2(project_code, run_id_int,
-                                      create_results_request_v2=CreateResultsRequestV2(results=results_to_send))
+                                      create_results_request_v2=CreateResultsRequestV2(results=results_to_send),
+                                      _request_timeout=self.config.testops.api.timeout)
         self.logger.log_debug(f"Results for run {run_id_int} sent successfully")
 
     def _prepare_result(self, project_code: str, result: Result) -> ResultCreate:

--- a/qase-python-commons/src/qase/commons/config.py
+++ b/qase-python-commons/src/qase/commons/config.py
@@ -109,6 +109,20 @@ class ConfigManager:
                                 self.config.testops.api.set_token(
                                     api.get("token"))
 
+                            if api.get("timeout"):
+                                self.config.testops.api.set_timeout(
+                                    api.get("timeout"))
+
+                            # `is not None`, not truthiness: 0 is a valid value
+                            # for both, meaning "no retries" / "no backoff".
+                            if api.get("retries") is not None:
+                                self.config.testops.api.set_retries(
+                                    api.get("retries"))
+
+                            if api.get("retryBackoff") is not None:
+                                self.config.testops.api.set_retry_backoff(
+                                    api.get("retryBackoff"))
+
                         if testops.get("project"):
                             self.config.testops.set_project(
                                 testops.get("project"))
@@ -287,6 +301,15 @@ class ConfigManager:
 
                 if key == 'QASE_TESTOPS_API_TOKEN':
                     self.config.testops.api.set_token(value)
+
+                if key == 'QASE_TESTOPS_API_TIMEOUT':
+                    self.config.testops.api.set_timeout(value)
+
+                if key == 'QASE_TESTOPS_API_RETRIES':
+                    self.config.testops.api.set_retries(value)
+
+                if key == 'QASE_TESTOPS_API_RETRY_BACKOFF':
+                    self.config.testops.api.set_retry_backoff(value)
 
                 if key == 'QASE_TESTOPS_PROJECT':
                     self.config.testops.set_project(value)

--- a/qase-python-commons/src/qase/commons/models/config/api.py
+++ b/qase-python-commons/src/qase/commons/models/config/api.py
@@ -4,12 +4,36 @@ from ..basemodel import BaseModel
 class ApiConfig(BaseModel):
     token: str = None
     host: str = None
+    timeout: int = None
+    retries: int = None
+    retry_backoff: int = None
 
     def __init__(self):
         self.host = "qase.io"
+        self.timeout = 30
+        self.retries = 3
+        self.retry_backoff = 2
 
     def set_token(self, token: str):
         self.token = token
 
     def set_host(self, host: str):
         self.host = host
+
+    def set_timeout(self, timeout: int):
+        timeout = int(timeout)
+        if timeout <= 0:
+            raise ValueError("API timeout should be greater than 0")
+        self.timeout = timeout
+
+    def set_retries(self, retries: int):
+        retries = int(retries)
+        if retries < 0:
+            raise ValueError("API retries should be 0 or greater")
+        self.retries = retries
+
+    def set_retry_backoff(self, retry_backoff: int):
+        retry_backoff = int(retry_backoff)
+        if retry_backoff < 0:
+            raise ValueError("API retry backoff should be 0 or greater")
+        self.retry_backoff = retry_backoff

--- a/qase-python-commons/src/qase/commons/reporters/testops.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops.py
@@ -8,6 +8,7 @@ from .. import Logger, ReporterException
 from ..client.base_api_client import BaseApiClient
 from ..models import Result
 from ..models.config.qaseconfig import QaseConfig
+from ..retry import send_with_retry
 
 DEFAULT_BATCH_SIZE = 200
 DEFAULT_THREAD_COUNT = 4
@@ -36,6 +37,8 @@ class QaseTestOps:
         self.send_semaphore = threading.Semaphore(DEFAULT_THREAD_COUNT)  # Semaphore to limit concurrent sends
         self.lock = threading.Lock()
         self.count_running_threads = 0
+        # Results in batches that could not be delivered after all retries.
+        self.lost_results = 0
 
         environment = self.config.environment
         if environment:
@@ -70,15 +73,28 @@ class QaseTestOps:
 
     def _send_results_threaded(self, results):
         try:
-            self.client.send_results(self.project_code, self.run_id, results)
+            send_with_retry(
+                lambda: self.client.send_results(self.project_code, self.run_id, results),
+                attempts=self.config.testops.api.retries,
+                backoff=self.config.testops.api.retry_backoff,
+                logger=self.logger,
+            )
             with self.lock:
                 self.processed.extend(results)
         except Exception as e:
+            # Account for the batch here rather than re-raising. The raise only
+            # ever surfaced as a PytestUnhandledThreadExceptionWarning that
+            # nothing acted on, which is how the loss stayed invisible.
             with self.lock:
-                self.logger.log(f"Error at sending results for run {self.run_id}: {e}", "error")
-            raise  # Re-raise the exception to be caught by the thread handler
+                self.lost_results += len(results)
+                self.logger.log(
+                    f"Failed to send {len(results)} results for run {self.run_id} "
+                    f"after {self.config.testops.api.retries} attempt(s): {e}",
+                    "error",
+                )
         finally:
-            self.count_running_threads -= 1
+            with self.lock:
+                self.count_running_threads -= 1
             self.send_semaphore.release()  # Release semaphore whether success or exception
 
     def _send_results(self) -> None:
@@ -101,7 +117,8 @@ class QaseTestOps:
             if results_to_send:
                 # Acquire semaphore before starting the send operation
                 self.send_semaphore.acquire()
-                self.count_running_threads += 1
+                with self.lock:
+                    self.count_running_threads += 1
 
                 # Start a new thread for sending results
                 send_thread = threading.Thread(target=self._send_results_threaded, args=(results_to_send,))
@@ -136,7 +153,17 @@ class QaseTestOps:
 
         while self.count_running_threads > 0:
             time.sleep(DEFAULT_THREAD_POLL_INTERVAL)
-        
+
+        if self.lost_results > 0:
+            # Leaving the run open is the signal. A run marked complete over
+            # partial data looks trustworthy and is not.
+            self.logger.log(
+                f"{self.lost_results} result(s) were not delivered to Qase. "
+                f"The run will not be marked complete so the gap stays visible.",
+                "error",
+            )
+            return
+
         if self.complete_after_run:
             self.logger.log_debug("Completing run")
             self.client.complete_run(self.project_code, self.run_id)
@@ -158,7 +185,7 @@ class QaseTestOps:
         if len(self.results) > 0:
             self._send_results()
         while self.count_running_threads > 0:
-            pass
+            time.sleep(DEFAULT_THREAD_POLL_INTERVAL)
         self.logger.log_debug("Worker completed")
 
     def add_result(self, result: Result) -> None:

--- a/qase-python-commons/src/qase/commons/reporters/testops_multi.py
+++ b/qase-python-commons/src/qase/commons/reporters/testops_multi.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import urllib.parse
 import copy
 
@@ -8,9 +9,11 @@ from .. import Logger, ReporterException
 from ..client.base_api_client import BaseApiClient
 from ..models import Result
 from ..models.config.qaseconfig import QaseConfig
+from ..retry import send_with_retry
 
 DEFAULT_BATCH_SIZE = 200
 DEFAULT_THREAD_COUNT = 4
+DEFAULT_THREAD_POLL_INTERVAL = 0.05
 
 
 class QaseTestOpsMulti:
@@ -44,6 +47,9 @@ class QaseTestOpsMulti:
         self.project_results: Dict[str, List[Result]] = {project.code: [] for project in self.multi_config.projects}
         self.project_runs: Dict[str, int] = {}  # Store run_id as int
         self.processed: Dict[str, List[Result]] = {project.code: [] for project in self.multi_config.projects}
+        # Results in batches that could not be delivered after all retries,
+        # counted per project so one project's loss does not hide another's.
+        self.lost_results: Dict[str, int] = {project.code: 0 for project in self.multi_config.projects}
 
         # Initialize environment for each project
         for project_code, project_data in self.project_configs.items():
@@ -101,15 +107,28 @@ class QaseTestOpsMulti:
         try:
             # Convert run_id to str for send_results (it will convert to int internally for API)
             run_id_str = str(run_id) if isinstance(run_id, int) else run_id
-            self.client.send_results(project_code, run_id_str, results)
+            send_with_retry(
+                lambda: self.client.send_results(project_code, run_id_str, results),
+                attempts=self.config.testops.api.retries,
+                backoff=self.config.testops.api.retry_backoff,
+                logger=self.logger,
+            )
             with self.lock:
                 self.processed[project_code].extend(results)
         except Exception as e:
+            # Account for the batch here rather than re-raising. The raise only
+            # ever surfaced as a PytestUnhandledThreadExceptionWarning that
+            # nothing acted on, which is how the loss stayed invisible.
             with self.lock:
-                self.logger.log(f"Error at sending results for project {project_code}, run {run_id}: {e}", "error")
-            raise
+                self.lost_results[project_code] = self.lost_results.get(project_code, 0) + len(results)
+                self.logger.log(
+                    f"Failed to send {len(results)} results for project {project_code}, "
+                    f"run {run_id} after {self.config.testops.api.retries} attempt(s): {e}",
+                    "error",
+                )
         finally:
-            self.count_running_threads -= 1
+            with self.lock:
+                self.count_running_threads -= 1
             self.send_semaphore.release()
 
     def _send_results_for_project(self, project_code: str) -> None:
@@ -141,7 +160,8 @@ class QaseTestOpsMulti:
         if results_to_send:
             # Acquire semaphore before starting the send operation
             self.send_semaphore.acquire()
-            self.count_running_threads += 1
+            with self.lock:
+                self.count_running_threads += 1
 
             # Start a new thread for sending results
             # run_id is stored as int, convert to str for thread (will be converted back to int in send_results)
@@ -230,10 +250,21 @@ class QaseTestOpsMulti:
 
         # Wait for all send operations to complete
         while self.count_running_threads > 0:
-            pass
+            time.sleep(DEFAULT_THREAD_POLL_INTERVAL)
 
         # Complete all test runs
         for project_code, project_data in self.project_configs.items():
+            if self.lost_results.get(project_code, 0) > 0:
+                # `continue`, not `return`: one project's loss must not stop
+                # the others completing. Leaving this run open is the signal.
+                self.logger.log(
+                    f"{self.lost_results[project_code]} result(s) were not delivered for "
+                    f"project {project_code}. Its run will not be marked complete so the "
+                    f"gap stays visible.",
+                    "error",
+                )
+                continue
+
             if project_data.get('complete_after_run'):
                 run_id = self.project_runs.get(project_code)
                 if run_id:
@@ -258,7 +289,7 @@ class QaseTestOpsMulti:
         if any(len(results) > 0 for results in self.project_results.values()):
             self._send_results()
         while self.count_running_threads > 0:
-            pass
+            time.sleep(DEFAULT_THREAD_POLL_INTERVAL)
         self.logger.log_debug("Worker completed")
 
     def add_result(self, result: Result) -> None:

--- a/qase-python-commons/src/qase/commons/retry.py
+++ b/qase-python-commons/src/qase/commons/retry.py
@@ -1,0 +1,94 @@
+"""Bounded retry for result uploads.
+
+Retries transport failures and the HTTP statuses that can succeed on a second
+attempt. Never retries a status that would be rejected identically -- an
+oversized batch, an invalid payload, an expired token -- where retrying only
+delays the error and adds load.
+
+Safe only because ResultCreate.id is populated: a request that was accepted
+but whose response was lost is indistinguishable from one that never arrived,
+and the idempotency key is what stops the retry creating duplicates.
+"""
+
+import time
+from typing import Callable, Optional
+
+RETRYABLE_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+_TRANSPORT_ERRORS = (ConnectionError, OSError, TimeoutError)
+
+
+def _urllib3_errors():
+    try:
+        from urllib3.exceptions import HTTPError
+
+        return (HTTPError,)
+    except ImportError:  # pragma: no cover - urllib3 is a hard dependency
+        return ()
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """True when another attempt could plausibly succeed."""
+    status = getattr(exc, "status", None)
+    if status is not None:
+        try:
+            return int(status) in RETRYABLE_STATUSES
+        except (TypeError, ValueError):
+            return False
+    return isinstance(exc, _TRANSPORT_ERRORS + _urllib3_errors())
+
+
+def retry_after_seconds(exc: BaseException) -> Optional[float]:
+    """Seconds requested by a Retry-After header, when there is one.
+
+    Qase answers 429 with roughly 60 seconds, which no short backoff ladder
+    survives, so honouring the header matters more than the ladder itself.
+    """
+    headers = getattr(exc, "headers", None)
+    if not headers:
+        return None
+    try:
+        value = headers.get("Retry-After")
+    except AttributeError:
+        return None
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        # The RFC also allows an HTTP-date. We do not parse it: falling back to
+        # the computed backoff is safer than guessing at a clock skew.
+        return None
+
+
+def send_with_retry(
+    send: Callable[[], None],
+    attempts: int,
+    backoff: int,
+    sleep: Callable[[float], None] = time.sleep,
+    logger=None,
+) -> None:
+    """Call send(), retrying retryable failures. Re-raises the last exception.
+
+    `attempts` is the total number of tries, not the number of retries on top
+    of the first: a configured `retries: 3` means three attempts in all, and
+    `retries: 0` still sends once but never retries.
+    """
+    attempts = max(1, attempts)
+    for attempt in range(1, attempts + 1):
+        try:
+            send()
+            return
+        except Exception as exc:
+            if attempt == attempts or not is_retryable(exc):
+                raise
+            delay = retry_after_seconds(exc)
+            if delay is None:
+                delay = backoff ** attempt
+            if logger:
+                logger.log(
+                    f"Upload attempt {attempt}/{attempts} failed ({exc}); "
+                    f"retrying in {delay}s",
+                    "warning",
+                )
+            sleep(delay)

--- a/qase-python-commons/tests/tests_qase_commons/test_api_config.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_api_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from qase.commons.models.config.api import ApiConfig
+
+
+def test_defaults():
+    config = ApiConfig()
+    assert config.timeout == 30
+    assert config.retries == 3
+    assert config.retry_backoff == 2
+
+
+def test_setters():
+    config = ApiConfig()
+    config.set_timeout(5)
+    config.set_retries(0)
+    config.set_retry_backoff(1)
+    assert (config.timeout, config.retries, config.retry_backoff) == (5, 0, 1)
+
+
+def test_setters_accept_strings_from_environment_variables():
+    config = ApiConfig()
+    config.set_timeout("5")
+    config.set_retries("0")
+    config.set_retry_backoff("1")
+    assert (config.timeout, config.retries, config.retry_backoff) == (5, 0, 1)
+
+
+def test_timeout_must_be_positive():
+    with pytest.raises(ValueError):
+        ApiConfig().set_timeout(0)
+
+
+def test_retries_cannot_be_negative():
+    with pytest.raises(ValueError):
+        ApiConfig().set_retries(-1)
+
+
+def test_retry_backoff_cannot_be_negative():
+    with pytest.raises(ValueError):
+        ApiConfig().set_retry_backoff(-1)

--- a/qase-python-commons/tests/tests_qase_commons/test_api_v2_client.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_api_v2_client.py
@@ -37,3 +37,18 @@ def test_prepare_result_ids_differ_between_results():
     first = client._prepare_result("DEMO", _result("a", "s-a"))
     second = client._prepare_result("DEMO", _result("b", "s-b"))
     assert first.id != second.id
+
+
+def test_send_results_passes_the_configured_timeout():
+    client = _client()
+    client.config.testops.api.timeout = 7
+    client.client_v2 = Mock()
+    client._prepare_result = Mock(return_value=Mock())
+
+    with patch("qase.commons.client.api_v2_client.ResultsApi") as results_api, patch(
+        "qase.commons.client.api_v2_client.CreateResultsRequestV2"
+    ):
+        client.send_results("DEMO", "1", [Mock()])
+
+    kwargs = results_api.return_value.create_results_v2.call_args.kwargs
+    assert kwargs["_request_timeout"] == 7

--- a/qase-python-commons/tests/tests_qase_commons/test_api_v2_client.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_api_v2_client.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock, patch
+
+from qase.commons.client.api_v2_client import ApiV2Client
+from qase.commons.models.result import Result
+
+
+def _client() -> ApiV2Client:
+    """An ApiV2Client whose __init__ is bypassed.
+
+    _prepare_result only touches self.config and self.logger, so building the
+    real client (which constructs API clients and reads certifi) is unnecessary.
+    """
+    client = ApiV2Client.__new__(ApiV2Client)
+    config = Mock()
+    config.exclude_params = []
+    config.testops.defect = False
+    config.root_suite = None
+    client.config = config
+    client.logger = Mock()
+    return client
+
+
+def _result(title: str, signature: str) -> Result:
+    result = Result(title=title, signature=signature)
+    result.execution.set_status("passed")
+    return result
+
+
+def test_prepare_result_sends_the_result_id_as_idempotency_key():
+    result = _result("test something", "sig-1")
+    prepared = _client()._prepare_result("DEMO", result)
+    assert prepared.id == result.id
+
+
+def test_prepare_result_ids_differ_between_results():
+    client = _client()
+    first = client._prepare_result("DEMO", _result("a", "s-a"))
+    second = client._prepare_result("DEMO", _result("b", "s-b"))
+    assert first.id != second.id

--- a/qase-python-commons/tests/tests_qase_commons/test_retry.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_retry.py
@@ -1,0 +1,117 @@
+import pytest
+
+from qase.commons.retry import is_retryable, retry_after_seconds, send_with_retry
+
+
+class FakeApiException(Exception):
+    """Shaped like the generated client's ApiException: .status and .headers."""
+
+    def __init__(self, status, headers=None):
+        super().__init__(f"status {status}")
+        self.status = status
+        self.headers = headers or {}
+
+
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+def test_retryable_statuses(status):
+    assert is_retryable(FakeApiException(status)) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 413, 422, 507])
+def test_non_retryable_statuses(status):
+    assert is_retryable(FakeApiException(status)) is False
+
+
+def test_transport_errors_are_retryable():
+    assert is_retryable(ConnectionResetError(104, "Connection reset by peer")) is True
+    assert is_retryable(OSError("network unreachable")) is True
+
+
+def test_unknown_exceptions_are_not_retryable():
+    assert is_retryable(ValueError("bad payload")) is False
+
+
+def test_retry_after_is_read_from_headers():
+    assert retry_after_seconds(FakeApiException(429, {"Retry-After": "60"})) == 60.0
+
+
+def test_retry_after_absent_or_unparsable():
+    assert retry_after_seconds(FakeApiException(429)) is None
+    assert retry_after_seconds(FakeApiException(429, {"Retry-After": "soon"})) is None
+    assert retry_after_seconds(ConnectionResetError()) is None
+
+
+def test_succeeds_without_retrying():
+    calls = []
+    send_with_retry(lambda: calls.append(1), attempts=3, backoff=2, sleep=lambda s: None)
+    assert len(calls) == 1
+
+
+def test_retries_until_success_with_exponential_backoff():
+    calls = []
+    slept = []
+
+    def send():
+        calls.append(1)
+        if len(calls) < 3:
+            raise ConnectionResetError()
+
+    send_with_retry(send, attempts=3, backoff=2, sleep=slept.append)
+    assert len(calls) == 3
+    assert slept == [2, 4]
+
+
+def test_gives_up_and_reraises_after_exhausting_attempts():
+    calls = []
+
+    def send():
+        calls.append(1)
+        raise ConnectionResetError()
+
+    with pytest.raises(ConnectionResetError):
+        send_with_retry(send, attempts=3, backoff=2, sleep=lambda s: None)
+    assert len(calls) == 3
+
+
+def test_does_not_retry_a_non_retryable_error():
+    calls = []
+
+    def send():
+        calls.append(1)
+        raise FakeApiException(413)
+
+    with pytest.raises(FakeApiException):
+        send_with_retry(send, attempts=3, backoff=2, sleep=lambda s: None)
+    assert len(calls) == 1
+
+
+def test_retry_after_overrides_backoff():
+    calls = []
+    slept = []
+
+    def send():
+        calls.append(1)
+        if len(calls) < 2:
+            raise FakeApiException(429, {"Retry-After": "60"})
+
+    send_with_retry(send, attempts=3, backoff=2, sleep=slept.append)
+    assert slept == [60.0]
+
+
+def test_attempts_of_one_means_no_retry():
+    calls = []
+
+    def send():
+        calls.append(1)
+        raise ConnectionResetError()
+
+    with pytest.raises(ConnectionResetError):
+        send_with_retry(send, attempts=1, backoff=2, sleep=lambda s: None)
+    assert len(calls) == 1
+
+
+def test_zero_attempts_still_tries_once():
+    """retries: 0 in config means "do not retry", not "do not send"."""
+    calls = []
+    send_with_retry(lambda: calls.append(1), attempts=0, backoff=2, sleep=lambda s: None)
+    assert len(calls) == 1

--- a/qase-python-commons/tests/tests_qase_commons/test_testops.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_testops.py
@@ -1,0 +1,103 @@
+import threading
+from unittest.mock import Mock
+
+from qase.commons.models.result import Result
+from qase.commons.reporters.testops import QaseTestOps
+
+
+def _reporter(client, retries=1, backoff=0):
+    """A QaseTestOps with __init__ bypassed, wired for the send path only.
+
+    The real __init__ builds API clients and calls get_project, which needs a
+    live server. Only the attributes the send and completion paths touch are
+    set here.
+    """
+    reporter = QaseTestOps.__new__(QaseTestOps)
+    reporter.config = Mock()
+    reporter.config.testops.status_filter = []
+    reporter.config.testops.api.retries = retries
+    reporter.config.testops.api.retry_backoff = backoff
+    reporter.config.testops.show_public_report_link = False
+    reporter.logger = Mock()
+    reporter.client = client
+    reporter.project_code = "DEMO"
+    reporter.run_id = 1
+    reporter.results = []
+    reporter.processed = []
+    reporter.lost_results = 0
+    reporter.lock = threading.Lock()
+    reporter.send_semaphore = threading.Semaphore(4)
+    reporter.count_running_threads = 0
+    reporter.complete_after_run = True
+    return reporter
+
+
+def _results(count):
+    return [Result(title=f"t{i}", signature=f"s{i}") for i in range(count)]
+
+
+def test_successful_send_records_processed_and_loses_nothing():
+    reporter = _reporter(Mock())
+    reporter._send_results_threaded(_results(3))
+    assert len(reporter.processed) == 3
+    assert reporter.lost_results == 0
+
+
+def test_exhausted_retries_count_the_batch_as_lost():
+    client = Mock()
+    client.send_results.side_effect = ConnectionResetError(104, "reset")
+    reporter = _reporter(client, retries=2)
+    reporter._send_results_threaded(_results(50))
+    assert reporter.lost_results == 50
+    assert reporter.processed == []
+
+
+def test_a_retryable_failure_is_retried_then_succeeds():
+    client = Mock()
+    client.send_results.side_effect = [ConnectionResetError(), None]
+    reporter = _reporter(client, retries=2)
+    reporter._send_results_threaded(_results(2))
+    assert client.send_results.call_count == 2
+    assert reporter.lost_results == 0
+    assert len(reporter.processed) == 2
+
+
+def test_the_thread_no_longer_raises_out_of_the_worker():
+    """The batch is accounted for instead of escaping as a thread exception.
+
+    Re-raising here only ever produced a PytestUnhandledThreadExceptionWarning
+    that nothing acted on, which is how the loss stayed silent.
+    """
+    client = Mock()
+    client.send_results.side_effect = ConnectionResetError()
+    reporter = _reporter(client, retries=1)
+    reporter._send_results_threaded(_results(1))  # must not raise
+    assert reporter.lost_results == 1
+
+
+def test_the_worker_releases_its_slot_even_when_the_batch_is_lost():
+    client = Mock()
+    client.send_results.side_effect = ConnectionResetError()
+    reporter = _reporter(client, retries=1)
+    reporter.count_running_threads = 1
+    reporter.send_semaphore.acquire()
+    reporter._send_results_threaded(_results(1))
+    assert reporter.count_running_threads == 0
+    assert reporter.send_semaphore.acquire(blocking=False) is True
+
+
+def test_complete_run_skips_completion_when_results_were_lost():
+    client = Mock()
+    reporter = _reporter(client)
+    reporter.lost_results = 100
+    reporter.complete_run()
+    client.complete_run.assert_not_called()
+    logged = " ".join(str(call) for call in reporter.logger.log.call_args_list)
+    assert "100" in logged
+
+
+def test_complete_run_completes_when_nothing_was_lost():
+    client = Mock()
+    reporter = _reporter(client)
+    reporter.complete_run()
+    client.complete_run.assert_called_once_with("DEMO", 1)

--- a/qase-python-commons/tests/tests_qase_commons/test_testops_multi.py
+++ b/qase-python-commons/tests/tests_qase_commons/test_testops_multi.py
@@ -20,6 +20,9 @@ class TestQaseTestOpsMulti:
         mock_config.testops.api = Mock()
         mock_config.testops.api.host = "qase.io"
         mock_config.testops.api.token = "test_token"
+        mock_config.testops.api.timeout = 30
+        mock_config.testops.api.retries = 1
+        mock_config.testops.api.retry_backoff = 0
         mock_config.testops.batch = Mock()
         mock_config.testops.batch.size = 200
         mock_config.testops.status_filter = []
@@ -382,3 +385,59 @@ class TestQaseTestOpsMulti:
         
         # Verify public report was enabled
         mock_client.enable_public_report.assert_called()
+
+    def test_exhausted_retries_count_the_batch_as_lost_for_that_project(self):
+        """A batch that cannot be delivered is counted against its own project."""
+        mock_config = self._create_mock_config()
+        mock_client = self._create_mock_client()
+        mock_client.send_results.side_effect = ConnectionResetError(104, "reset")
+
+        reporter = QaseTestOpsMulti(mock_config, Mock(), mock_client)
+        results = [Result(title=f"t{i}", signature=f"s{i}") for i in range(50)]
+        reporter._send_results_threaded("PROJ1", 123, results)
+
+        assert reporter.lost_results["PROJ1"] == 50
+        assert reporter.lost_results["PROJ2"] == 0
+        assert reporter.processed["PROJ1"] == []
+
+    def test_a_retryable_failure_is_retried_then_succeeds(self):
+        """A transient failure that clears on the second attempt loses nothing."""
+        mock_config = self._create_mock_config()
+        mock_config.testops.api.retries = 2
+        mock_client = self._create_mock_client()
+        mock_client.send_results.side_effect = [ConnectionResetError(), None]
+
+        reporter = QaseTestOpsMulti(mock_config, Mock(), mock_client)
+        results = [Result(title="t", signature="s")]
+        reporter._send_results_threaded("PROJ1", 123, results)
+
+        assert mock_client.send_results.call_count == 2
+        assert reporter.lost_results["PROJ1"] == 0
+        assert len(reporter.processed["PROJ1"]) == 1
+
+    def test_the_worker_does_not_raise_out_of_the_thread(self):
+        """The batch is accounted for instead of escaping as a thread exception."""
+        mock_config = self._create_mock_config()
+        mock_client = self._create_mock_client()
+        mock_client.send_results.side_effect = ConnectionResetError()
+
+        reporter = QaseTestOpsMulti(mock_config, Mock(), mock_client)
+        reporter._send_results_threaded("PROJ1", 123, [Result(title="t", signature="s")])
+
+        assert reporter.lost_results["PROJ1"] == 1
+
+    def test_completion_is_skipped_only_for_projects_that_lost_results(self):
+        """One project's loss must not stop another project's run completing."""
+        mock_config = self._create_mock_config()
+        mock_client = self._create_mock_client()
+        mock_client.create_test_run.side_effect = [123, 456]
+
+        reporter = QaseTestOpsMulti(mock_config, Mock(), mock_client)
+        reporter.start_run()
+        reporter.lost_results["PROJ1"] = 25
+
+        reporter.complete_run()
+
+        completed = [call.args[0] for call in mock_client.complete_run.call_args_list]
+        assert "PROJ1" not in completed
+        assert "PROJ2" in completed


### PR DESCRIPTION
Related #504.

## Problem

`QaseTestOps._send_results` cleared `self.results` when it *started* the upload thread, not when the server confirmed the batch. A failed upload therefore destroyed its own results: they were in neither `self.results` nor `self.processed`, so `get_results()` could not see them and the local fallback could not recover them. The thread raised, pytest downgraded it to `PytestUnhandledThreadExceptionWarning`, the run was marked complete, and the process exited 0.

Reproduced with a local harness: **205 of 305 results lost behind an "all passed" summary**, with the run showing as complete.

## Changes

- **Send `ResultCreate.id`.** `Result` already generated the UUID; it was dropped when building the payload. The backend substitutes a random hash when the field is absent, so this had to land *before* retries or every retry would duplicate results.
- **Retry uploads** on transport errors and 408/429/5xx, with exponential backoff. Never on 400/401/403/404/413/422/507 — those fail identically on a second attempt. `Retry-After` replaces the computed backoff, which matters because Qase answers 429 with ~60s.
- **Pin `Configuration.retries = 0`.** It was `None`, so urllib3's defaults applied and would have multiplied with the application policy — a 3-attempt policy issuing 9 requests, the opposite of what is wanted on a 429.
- **Set a request timeout.** There was none, so a stalled connection hung the session at teardown until CI killed the job.
- **Report unrecoverable batches.** Loss is counted and logged with the count, and the run is left open rather than marked complete over partial data.
- **Lock `count_running_threads`**, since the completion decision now depends on it.
- Same treatment for `testops_multi.py`, per project: one project's loss no longer blocks the others from completing.

New config under `testops.api` (defaults shown), with `QASE_TESTOPS_API_*` overrides:

```json
{"testops": {"api": {"timeout": 30, "retries": 3, "retryBackoff": 2}}}
```

`retries: 3` means three attempts in total; `retries: 0` sends once without retrying.

## Verification

Fault injection against a fake Qase server, 305 results, batch size 50:

| Scenario | before | after |
| --- | --- | --- |
| no faults | 305 | 305 |
| connection reset | 205 (100 lost) | **305** |
| resets wider than the retry ladder | 50, run completed | 50, **run left open** |
| 429 with `Retry-After` | 205 (100 lost) | **305** |
| 500 after a partial store | 255 (50 lost) | **305, 0 duplicates, 50 deduplicated** |
| server never responds | never terminated | **terminates, 305** |
| connection reset under `-n 4` | 205 (100 lost) | **305** |

The partial-store row is the idempotency check: the retry re-delivers 50 results the server already holds, and they are recognised by `id` instead of being stored twice. Without the first commit that row would read `50 duplicates`.

287 tests pass in `qase-python-commons`, 105 in `qase-pytest`.